### PR TITLE
Use this.options instead of options var

### DIFF
--- a/modules/localtunnel/index.js
+++ b/modules/localtunnel/index.js
@@ -12,7 +12,7 @@ module.exports = function nuxtLocaltunnel (options) {
   const host = process.env.HOST || process.env.npm_package_config_nuxt_host || 'localhost'
 
   const opts = {
-    subdomain: options.subdomain || process.env.npm_package_name,
+    subdomain: this.options.subdomain || process.env.npm_package_name,
     local_host: host
   }
 


### PR DESCRIPTION
Hello,

A small PR to use this.options for setting the subdomain.

Nevertheless, I was wondering what was the use of the options parameters, as there is no need of it in almost every module.

Keep up the good work