### PR TITLE
Fix options reference and moduleOptions typo

### DIFF
--- a/modules/bootstrap-vue/index.js
+++ b/modules/bootstrap-vue/index.js
@@ -1,13 +1,13 @@
 const path = require('path')
 
-module.exports = function nuxtBootstrapVue (moduleOtions) {
+module.exports = function nuxtBootstrapVue (moduleOptions) {
   // Conditionally require bootstrap original css too if not explicitly disabled
-  if (moduleOtions.css !== false) {
+  if (moduleOptions.css !== false) {
     this.options.css.unshift('bootstrap/dist/css/bootstrap.css')
   }
 
   // Register plugin
-  this.addPlugin({ src: path.resolve(__dirname, 'plugin.js'), options })
+  this.addPlugin({ src: path.resolve(__dirname, 'plugin.js'), moduleOptions })
 
   // Add library styles
   this.options.css.push('bootstrap-vue/dist/bootstrap-vue.css')


### PR DESCRIPTION
ReferenceError: options is not defined
    at Module.nuxtBootstrapVue (/home/rich/Projects/da-lee/node_modules/@nuxtjs/bootstrap-vue/index.js:10:63)
    at /home/rich/Projects/da-lee/node_modules/nuxt/dist/nuxt.js:1784:29
    at Promise (<anonymous>)
    at F (/home/rich/Projects/da-lee/node_modules/core-js/library/modules/_export.js:35:28)
    at Module.addModule (/home/rich/Projects/da-lee/node_modules/nuxt/dist/nuxt.js:1783:14)
    at /home/rich/Projects/da-lee/node_modules/nuxt/dist/nuxt.js:198:14
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:169:7)
    at Function.Module.runMain (module.js:607:11)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
error Command failed with exit code 1.