### PR TITLE
feat: see what you are filtering by

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,7 +69,10 @@
       <p class="mb-4 text-forest-night">
         {{ filteredModules.length }} module{{ filteredModules.length !== 1 ? 's' : '' }} found
         <template v-if="selectedCategory || q">
-          <a @click.prevent="clearFilters" href="/" class="hover:text-grey-darkest">(<u>clear filters</u>)</a>
+          <p>Filter{{ selectedCategory && q ? 's' : '' }}: 
+            <b>{{selectedCategory}}</b>{{ selectedCategory && q ? ', ' : '' }}<b>{{q}}</b>
+            <a @click.prevent="clearFilters" href="/" class="hover:text-grey-darkest">(<u>clear filter{{ selectedCategory && q ? 's' : '' }}</u>)</a>
+          </p>
         </template>
       </p>
       <!-- Module cards -->


### PR DESCRIPTION
You can filter by query and by category. Sometimes it is not clear when you filter by query and then start clicking the categories that the query is still being filtered. This shows you what is being filtered so you can choose to clear the filter and continue only by category for example