### PR TITLE
feat: add link to modules docs

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -111,14 +111,17 @@
     </div>
 
     <!-- Footer -->
-    <div class="container mx-auto flex justify-center px-4 sm:px-0 pt-12 text-stone-green items-center space-x-2">
-      <a href="https://vercel.com" rel=noopener target="_blank" aria-label="go to vercel">
-        <IconVercel alt="Vercel" />
-      </a>
-      <a href="https://nuxtjs.org" rel=noopener target="_blank" aria-label="go to nuxt">
-        <IconWithNuxt alt="Nuxt" />
-      </a>
-    </div>
+    <footer class="container mx-auto flex flex-col justify-center pt-12 text-stone-green items-center">
+      <p>For more information on Nuxt modules, including how to create a module, check out our <a href="https://nuxtjs.org/guides/directory-structure/modules" rel="noopener" target="_blank" class="text-md leading-4 items-center space-x-1 text-grey border-b border-stone-green hover:text-green-500 hover:border-green-600">docs</a></p>
+      <div class="flex justify-center px-4 sm:px-0 pt-6 space-x-2">
+        <a href="https://vercel.com" rel=noopener target="_blank" aria-label="go to vercel">
+          <IconVercel alt="Vercel" />
+        </a>
+        <a href="https://nuxtjs.org" rel=noopener target="_blank" aria-label="go to nuxt">
+          <IconWithNuxt alt="Nuxt" />
+        </a>
+      </div>
+    </footer>
   </div>
 </template>
 


### PR DESCRIPTION
adds a link to footer for those who want to go direct to our modules docs so they can create their own Nuxt module or learn how modules work