### PR TITLE
fix(icons): prevent `url-loader` from loading small files as data url

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -35,5 +35,14 @@ export default /*<NuxtConfig>*/ {
     server: 'https://ackee.nuxtjs.com',
     domainId: 'ab823e69-2425-4a16-85c8-bd9b42d11e1e',
     detailed: true
+  },
+  build: {
+    extend(config) {
+      const rule = config.module.rules.find(rule => String(rule.test).includes('svg'))
+      const urlLoader = rule.use.find(r => r.loader === 'url-loader')
+      if (urlLoader) {
+        urlLoader.options.limit = 0
+      }
+    }
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,11 @@
 export default /*<NuxtConfig>*/ {
   target: 'static',
   components: true,
+  build: {
+    loaders: {
+      imgUrl: { limit: 0 }
+    }
+  },
   buildModules: [
     // Doc: https://tailwindcss.nuxtjs.org
     '@nuxtjs/tailwindcss',
@@ -35,14 +40,5 @@ export default /*<NuxtConfig>*/ {
     server: 'https://ackee.nuxtjs.com',
     domainId: 'ab823e69-2425-4a16-85c8-bd9b42d11e1e',
     detailed: true
-  },
-  build: {
-    extend(config) {
-      const rule = config.module.rules.find(rule => String(rule.test).includes('svg'))
-      const urlLoader = rule.use.find(r => r.loader === 'url-loader')
-      if (urlLoader) {
-        urlLoader.options.limit = 0
-      }
-    }
   }
 }


### PR DESCRIPTION
`url-loader` returns a DataURL if the file is smaller than a byte limit, because of this behavior svg icons of `maintainer` and `start` are loads as data url. These icons are used inside the loop therefore loading them as data-url will increase page sige.

This PR change byte limit to zero and disables dataURL feature of `url-loader`