### PR TITLE
fix(modules): yandex metrika module description

### DIFF
--- a/modules/yandex-metrika.yml
+++ b/modules/yandex-metrika.yml
@@ -1,6 +1,6 @@
 name: yandex-metrika
-description: !<tag:yaml.org,2002:js/undefined> ''
-repo: nuxt-community/modules#master/packages/yandex-metrika
+description: Yandex metrika Module for Nuxt.js
+repo: nuxt-community/yandex-metrika-module
 npm: '@nuxtjs/yandex-metrika'
 icon: ''
 github: 'https://github.com/nuxt-community/yandex-metrika-module'

--- a/modules/yandex-metrika.yml
+++ b/modules/yandex-metrika.yml
@@ -3,8 +3,8 @@ description: !<tag:yaml.org,2002:js/undefined> ''
 repo: nuxt-community/modules#master/packages/yandex-metrika
 npm: '@nuxtjs/yandex-metrika'
 icon: ''
-github: 'https://github.com/nuxt-community/modules/tree/master/packages/yandex-metrika'
-website: 'https://github.com/nuxt-community/modules/tree/master/packages/yandex-metrika'
+github: 'https://github.com/nuxt-community/yandex-metrika-module'
+website: 'https://github.com/nuxt-community/yandex-metrika-module'
 learn_more: 'https://metrica.yandex.com/about'
 category: Analytics
 type: community


### PR DESCRIPTION
I saw a strange description about `yandex-metrika` during extraction.
I also took the opportunity to put the correct url of the repository (this is something that could have been added to the previous MR)