### PR TITLE
ci: lint yaml files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@master
 
+      - name: debug
+        run: ls && pwd && echo $GITHUB_WORKSPACE
+
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: ./modules/.
+
       - name: cache node_modules
         uses: actions/cache@v2
         with:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,13 @@
+---
+
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+  quoted-strings:
+    required: only-when-needed
+    quote-type: single
+    extra-allowed: [^https://, ^http://, \', ':']
+
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ Then visit http://localhost:3000.
 
 In development, the npm downloads and GitHub stars will be mocked.
 
+#### Linting
+
+To run the yamllint locally you will need to install the binary on your machine. See [here](https://yamllint.readthedocs.io/en/stable/quickstart.html) for instructions.
+
+Once you have the yamllint binary you can run the linter manually with: 
+
+```
+yarn lint
+```
+
 ### Production
 
 Create a [personnal GitHub token](https://github.com/settings/tokens) (no scope selected) and add it to `.env`:

--- a/modules/darkmode.js.yml
+++ b/modules/darkmode.js.yml
@@ -1,12 +1,12 @@
 name: darkmode.js
-description: "Add darkmode / nightmode to your Nuxt.js project in a few seconds"
+description: Add darkmode / nightmode to your Nuxt.js project in a few seconds
 repo: sandoche/nuxtjs-darkmode-js-module#main
 npm: nuxtjs-darkmode-js-module
-icon: 'darkmode.png'
+icon: darkmode.png
 github: 'https://github.com/sandoche/nuxtjs-darkmode-js-module'
 website: 'https://github.com/sandoche/nuxtjs-darkmode-js-module'
 learn_more: ''
-category: 'UI'
+category: UI
 type: 3rd-party
 maintainers:
   - name: sandoche

--- a/modules/feed.yml
+++ b/modules/feed.yml
@@ -1,5 +1,5 @@
 name: feed
-description: 'Feed module enables everyone to have RSS, Atom and Json.'
+description: Feed module enables everyone to have RSS, Atom and Json.
 repo: nuxt-community/feed-module
 npm: '@nuxtjs/feed'
 icon: ''

--- a/modules/fontagon.yml
+++ b/modules/fontagon.yml
@@ -2,11 +2,11 @@ name: fontagon
 description: Easy convert SVG from nuxt to icon font.
 repo: kdydesign/nuxt-fontagon
 npm: nuxt-fontagon
-icon: 'fontagon.png'
+icon: fontagon.png
 github: 'https://github.com/kdydesign/nuxt-fontagon'
 website: 'https://github.com/kdydesign/nuxt-fontagon'
 learn_more: ''
-category: 'Libraries'
+category: Libraries
 type: 3rd-party
 maintainers:
   - name: kdydesign

--- a/modules/intercom.yml
+++ b/modules/intercom.yml
@@ -1,5 +1,5 @@
 name: intercom
-description: 'Conversational, messenger-based experiences with Intercom Module for Nuxt.js'
+description: Conversational, messenger-based experiences with Intercom Module for Nuxt.js
 repo: hex-digital/nuxt-intercom
 npm: '@hexdigital/nuxt-intercom'
 icon: intercom.png

--- a/modules/notion.yml
+++ b/modules/notion.yml
@@ -1,12 +1,12 @@
 name: vue-notion
-description: 'Vue renderer for Notion pages'
+description: Vue renderer for Notion pages
 repo: janniks/vue-notion
 npm: vue-notion
 icon: notion.svg
 github: 'https://github.com/janniks/vue-notion'
 website: 'https://github.com/janniks/vue-notion'
 learn_more: ''
-category: 'CMS'
+category: CMS
 type: 3rd-party
 maintainers:
   - name: janniks

--- a/modules/nuxt-use-sound.yml
+++ b/modules/nuxt-use-sound.yml
@@ -1,12 +1,12 @@
 name: nuxt-use-sound
-description: "A Nuxt module for playing sound effects."
+description: A Nuxt module for playing sound effects.
 repo: Tahul/nuxt-use-sound
 npm: nuxt-use-sound
-icon: 'nuxt-use-sound.svg'
+icon: nuxt-use-sound.svg
 github: 'https://github.com/Tahul/nuxt-use-sound'
 website: 'https://github.com/Tahul/nuxt-use-sound'
 learn_more: 'https://github.com/Tahul/vue-use-sound'
-category: 'Libraries'
+category: Libraries
 type: 3rd-party
 maintainers:
   - name: Tahul

--- a/modules/plausible.yml
+++ b/modules/plausible.yml
@@ -2,11 +2,11 @@ name: plausible
 description: Plausible analytics for Vue.js and Nuxt
 repo: moritzsternemann/vue-plausible
 npm: vue-plausible
-icon: 'plausible.png'
+icon: plausible.png
 github: 'https://github.com/moritzsternemann/vue-plausible'
 website: 'https://github.com/moritzsternemann/vue-plausible'
 learn_more: ''
-category: 'Analytics'
+category: Analytics
 type: 3rd-party
 maintainers:
   - name: moritzsternemann

--- a/modules/sanity.yml
+++ b/modules/sanity.yml
@@ -1,5 +1,5 @@
 name: sanity
-description: 'Access text, images, and other media with Nuxt.js and the Sanity headless CMS.'
+description: Access text, images, and other media with Nuxt.js and the Sanity headless CMS.
 repo: nuxt-community/sanity-module#main
 npm: '@nuxtjs/sanity'
 icon: sanity.png

--- a/modules/svg-loader.yml
+++ b/modules/svg-loader.yml
@@ -1,5 +1,5 @@
 name: svg-loader
-description: 'Nuxt SVG Loader - SVGs as components, also on the server side!'
+description: Nuxt SVG Loader - SVGs as components, also on the server side!
 repo: Developmint/nuxt-svg-loader
 npm: nuxt-svg-loader
 icon: ''

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "generate": "nuxt-ts generate",
     "release": "yarn cli version && npm publish",
     "start": "nuxt-ts start",
-    "sync": "yarn cli sync"
+    "sync": "yarn cli sync",
+    "lint": "yamllint modules/**"
   },
   "devDependencies": {
     "@nuxt/content": "^1.11.1",


### PR DESCRIPTION
see: https://github.com/nuxt/modules/pull/104#issuecomment-782035931

The point is to reduce the overhead for devs to contribute their own modules from the back and forth from yaml inconsistencies. 

I would have used a js based linter, which we could of setup with husky hooks, however, this implementation is the only one that will check for quotes being used incorrectly and generally seems to have a better API.