### PR TITLE
💄 Padding for non sm screen

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -91,7 +91,7 @@
     </div>
 
     <!-- Modules list -->
-    <div class="container px-4 mx-auto sm:px-0">
+    <div class="container px-4 mx-auto">
       <div class="flex flex-col items-center justify-between sm:flex-row">
         <!-- Clear filters -->
         <p class="mb-4 text-forest-night">


### PR DESCRIPTION
The "sm:px-0" removes the x paddings on big screens. Which should not be the case.
Depending on your screen size, with the code on main, the text / modules can touch the sides of you screen (this is ugly).