### PR TITLE
fix: updated compatibility status for windicss.yml

### DIFF
--- a/modules/windicss.yml
+++ b/modules/windicss.yml
@@ -15,5 +15,5 @@ maintainers:
     avatar: https://avatars.githubusercontent.com/u/5326365?v=4
 compatibility:
   2.x: working
-  2.x-bridge: unknown
-  3.x: unknown
+  2.x-bridge: working
+  3.x: working


### PR DESCRIPTION
I have tested windicss module with latest verison of Nuxt 3 and Nuxt Bridge. It's working fine.
Even the module's readme.md has info on how to implement in Nuxt 3.