### PR TITLE
fix(website): fix a11y issues

### DIFF
--- a/website/components/CardModule.vue
+++ b/website/components/CardModule.vue
@@ -65,7 +65,7 @@
               >
             </h2>
             <p
-              class="text-sky-dark dark:text-white text-sm font-normal line-clamp-3 mt-2 opacity-85"
+              class="text-sky-dark dark:text-white dark:opacity-85 text-sm font-normal line-clamp-3 mt-2"
             >
               {{ module.description }}
             </p>

--- a/website/components/TheHeader.vue
+++ b/website/components/TheHeader.vue
@@ -4,7 +4,7 @@
       class="text-display-5 sm:text-display-4 md:text-display-3 pb-1 sm:pb-2 md:pb-6 font-serif overflow-ellipsis overflow-hidden"
     >
       Explore
-      <span class="text-primary">Nuxt</span> Modules
+      <span class="text-primary-800 dark:text-primary">Nuxt</span> Modules
     </h1>
     <p
       class="text-body-md sm:text-body-lg md:text-body-xl max-w-3xl text-secondary-darker dark:text-secondary-lightest"

--- a/website/components/TheSearch.vue
+++ b/website/components/TheSearch.vue
@@ -10,17 +10,9 @@
     </div>
     <slot />
     <button aria-label="Toggle theme" class="!outline-none" @click="toggleDarkMode()">
-      <ColorScheme placeholder="..." tag="span">
-        <span v-if="$colorMode.preference === 'system'">
-          <IconSystem aria-label="System theme" />
-        </span>
-        <span v-else-if="$colorMode.value === 'dark'">
-          <IconMoon />
-        </span>
-        <span v-else-if="$colorMode.value === 'light'">
-          <IconSun />
-        </span>
-      </ColorScheme>
+      <IconMoon v-if="$colorMode.value === 'dark'" />
+      <IconSun v-else-if="$colorMode.value === 'light'" />
+      <IconSystem v-else aria-label="System theme" />
     </button>
   </div>
 </template>

--- a/website/components/TheSearch.vue
+++ b/website/components/TheSearch.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="flex items-center justify-between w-full container mx-auto px-4 sm:px-0 py-2">
     <div class="flex">
-      <IconNuxtLogo alt="Nuxt" width="40" height="40" />
-      <div class="text-2xl my-auto ml-1 pt-0.5">
-        <a href="/">Modules</a>
-      </div>
+      <a href="/" class="inline-flex text-2xl">
+        <IconNuxtLogo alt="Nuxt" width="40" height="40" />
+        <span class="my-auto ml-1 pt-0.5">
+          Modules
+        </span>
+      </a>
     </div>
     <slot />
     <button aria-label="Toggle theme" class="!outline-none" @click="toggleDarkMode()">

--- a/website/components/TheSearch.vue
+++ b/website/components/TheSearch.vue
@@ -3,7 +3,7 @@
     <div class="flex">
       <IconNuxtLogo alt="Nuxt" width="40" height="40" />
       <div class="text-2xl my-auto ml-1 pt-0.5">
-        Modules
+        <a href="/">Modules</a>
       </div>
     </div>
     <slot />

--- a/website/components/TheStats.vue
+++ b/website/components/TheStats.vue
@@ -7,7 +7,7 @@
           aria-hidden="true"
         >Total</span>
         <dd
-          class="text-3xl font-black text-primary-600 leading-none sm:text-6xl"
+          class="text-3xl font-black text-primary-800 dark:text-primary leading-none sm:text-6xl"
           aria-describedby="item-1"
         >
           {{ modules.length }}
@@ -25,7 +25,7 @@
           aria-hidden="true"
         >Total</span>
         <dd
-          class="text-3xl font-black text-primary-600 leading-none sm:text-6xl"
+          class="text-3xl font-black text-primary-800 dark:text-primary leading-none sm:text-6xl"
         >
           {{ numberFormat(downloadsTotal) }}
         </dd>
@@ -41,7 +41,7 @@
           aria-hidden="true"
         >Total</span>
         <dd
-          class="text-3xl font-black text-primary-600 leading-none sm:text-6xl"
+          class="text-3xl font-black text-primary-800 dark:text-primary leading-none sm:text-6xl"
         >
           {{ maintainersTotal }}
         </dd>

--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -181,7 +181,7 @@
                       :key="key"
                       type="button"
                       :aria-label="`sort by ${key}`"
-                      class="flex items-center justify-center p-1 px-2 bg-white shadow-xs w-28 hover:bg-cloudy-grey focus:text-grey-darkest text-forest-night focus:outline-none rounded-b-md"
+                      class="flex items-center justify-center p-1 px-2 dark:bg-secondary-darkest bg-white shadow-xs w-28 hover:bg-cloudy-grey focus:text-grey-darkest text-forest-night focus:outline-none rounded-b-md"
                       @click="selectSortBy(key)"
                     >
                       {{ option.label }}

--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -15,7 +15,7 @@
               placeholder="Search a module (name, category, username, etc.)"
             >
             <span
-              class="absolute hidden px-2 py-1 text-gray-400 border border-sky-light rounded-md opacity-50 md:inline-block text-md top-1 right-4 leading-6"
+              class="absolute hidden px-2 py-1 text-gray opacity-90 dark:text-gray-300 border border-sky-light rounded-md md:inline-block text-md top-1 right-4 leading-6"
             >/</span>
           </label>
         </div>
@@ -59,7 +59,7 @@
           >
             Nuxt version
           </h2>
-          <p class="text-sm text-gray-500 mb-4">
+          <p class="text-sm text-gray-700 dark:text-gray-300 mb-4">
             Show modules working with:
           </p>
           <div class="flex flex-col space-y-3">


### PR DESCRIPTION
- Ensure color contrasts matching AAA (using [this extension](https://chrome.google.com/webstore/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf))
- Allow clicking on modules in nav "Modules"
- Fix sort drop down background
- Make "[logo] Modules" in nav clickable
- Replace .... with 

---
Todo 1:
- Color mode sets "system" as a preference. This makes issues when system theme is actually dark. We need to click twice to switch to light theme. 
- Color mode seems not restoring cookie state for server side-rendering

Todo 2:
I couldn't figure out for this situation that when a category is selected and clicked again, goes into a bad situation
![image](https://user-images.githubusercontent.com/5158436/141506515-718458cb-ec9f-4632-ae13-8fa57c517736.png)

