### PR TITLE
💄 Setting a padding for main block

### DIFF
--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -45,7 +45,7 @@
     </div>
 
     <!-- Body -->
-    <div class="container px-4 sm:px-0 mx-auto pt-8 grid grid-cols-1 sm:grid-cols-5 gap-8">
+    <div class="container px-4 sm:px-10 mx-auto pt-8 grid grid-cols-1 sm:grid-cols-5 gap-8">
       <!-- Sidebar -->
       <div class="col-span-1 space-y-10 hidden lg:block">
         <!-- Nuxt versions -->


### PR DESCRIPTION
Setting up a default padding (more beautiful).
This was already done on previous version through #189 
"The "sm:px-0" removes the x paddings on big screens. Which should not be the case.
Depending on your screen size, with the code on main, the text / modules can touch the sides of you screen (this does not look nice)."