### PR TITLE
design: responsive found modules & footer

### DIFF
--- a/website/components/TheFooter.vue
+++ b/website/components/TheFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="container flex flex-col items-center justify-center pt-12 mx-auto text-stone-green">
+  <footer class="container flex flex-col items-center justify-center pt-12 px-4 mx-auto text-stone-green">
     <p>For more information on Nuxt modules, including how to create a module, check out our <a href="https://nuxtjs.org/guides/directory-structure/modules" rel="noopener" target="_blank" class="items-center space-x-1 leading-4 border-b text-md text-grey border-stone-green hover:text-green-500 hover:border-green-600">docs</a>.</p>
     <div class="flex justify-center px-4 pt-6 space-x-2 sm:px-0">
       <a href="https://vercel.com" rel="noopener" target="_blank" aria-label="go to vercel">

--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -45,7 +45,7 @@
     </div>
 
     <!-- Body -->
-    <div class="container px-4 sm:px-0 mx-auto pt-8 grid grid-cols-1 sm:grid-cols-5 gap-8">
+    <div class="container px-4 mx-auto pt-8 grid grid-cols-1 lg:grid-cols-5 gap-8">
       <!-- Sidebar -->
       <div class="col-span-1 space-y-10 hidden lg:block">
         <!-- Nuxt versions -->
@@ -132,10 +132,10 @@
         </div>
 
         <!-- Result, Sort -->
-        <div class="flex flex-col items-center justify-between h-18 sm:flex-row p-5 mb-4 bg-gray-100 dark:bg-secondary-darkest rounded-lg">
+        <div class="flex flex-col items-center justify-between min-h-18 sm:flex-row p-5 mb-4 bg-gray-100 dark:bg-secondary-darkest rounded-lg">
           <div>
             <span class="font-black text-2xl">{{ filteredModules.length }}</span>
-            module{{ filteredModules.length !== 1 ? 's' : '' }} found
+            module{{ filteredModules.length > 1 ? 's' : '' }} found
           </div>
           <div>
             <div v-show="!q" class="flex items-center text-forest-night">


### PR DESCRIPTION
Hi!
This sets a default padding to Footer.
This solves problems with the "X module(s) found" => min-height, centering on tablets and text ("0 modules found" => "0 module found").
Previous PR #227 may be broken.