### PR TITLE
chore: removing unused directive

### DIFF
--- a/website/pages/index.vue
+++ b/website/pages/index.vue
@@ -188,14 +188,6 @@ const sortFields = {
 
 export default {
   components: { LazyHydrate },
-  directives: {
-    focus: {
-      // directive definition
-      inserted (el) {
-        el?.focus()
-      }
-    }
-  },
   async asyncData () {
     return await fetchModules()
   },


### PR DESCRIPTION
This code is not used anymore (no v-focus in app).
At the begining, an autofocus was set on all devices when page started (cf: ae84ec82e04edc832a901173aba86aa1613d16b6)

Now, autofocus is set only on desktop (PR#84 ):
```
if (!isMobile()) {
  this.focusSearchInput()
}
```