### PR TITLE
fix: setting a minimum padding for the header

### DIFF
--- a/website/components/TheSearch.vue
+++ b/website/components/TheSearch.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center gap-4 justify-between w-full container mx-auto px-4 sm:px-0 py-2">
+  <div class="flex items-center gap-4 justify-between w-full container mx-auto px-4 py-2">
     <div class="flex">
       <a href="/" class="inline-flex text-2xl">
         <IconNuxtLogo alt="Nuxt" width="40" height="40" />


### PR DESCRIPTION
Suggestion: there should always be a minimum px-4, it's much more beautiful.

![nuxtModulesHeaderDefaultPadding](https://user-images.githubusercontent.com/12933109/142662990-33476f43-118f-46c0-b68f-19dafb990d00.png)