### PR TITLE
feat(website): use contributors counting

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,12 @@ export interface MaintainerInfo {
   twitter?: string
 }
 
+export interface GithubContributor {
+  login: string
+  name?: string
+  avatar_url?: string
+}
+
 export type CompatibilityStatus = 'working' | 'wip' | 'unknown' | 'not-working'
 export type ModuleType = 'community' | 'official' | '3rd-party'
 
@@ -28,6 +34,7 @@ export interface ModuleInfo {
   category: (typeof categories)[number]
   type: ModuleType
   maintainers: MaintainerInfo[]
+  contributors: GithubContributor[]
   compatibility: ModuleCompatibility
 
   // Fetched in realtime API for modules.nuxt.org

--- a/website/components/CardModule.vue
+++ b/website/components/CardModule.vue
@@ -103,19 +103,19 @@
       </div>
       <div class="flex -space-x-3 hover:space-x-0 absolute right-0 -bottom-1 hover:bg-white  dark:hover:bg-sky-darkest">
         <a
-          v-for="maintainer of mod.maintainers"
-          :key="maintainer.github"
-          v-tooltip="{ content: maintainer.name || maintainer.github, classes: ['bg-secondary-dark', 'dark:bg-sky-black', 'text-white', 'px-2', 'py-1', 'rounded', 'text-sm', 'mb-2'] }"
-          :aria-label="maintainer.github"
-          :href="githubUrl(maintainer)"
+          v-for="contributor of mod.contributors.slice(0, 5).reverse()"
+          :key="contributor.login"
+          v-tooltip="{ content: contributor.name || contributor.login, classes: ['bg-secondary-dark', 'dark:bg-sky-black', 'text-white', 'px-2', 'py-1', 'rounded', 'text-sm', 'mb-2'] }"
+          :aria-label="contributor.name || contributor.login"
+          :href="`https://github.com/${contributor.login}`"
           target="_blank"
           rel="noopener"
         >
           <!-- TODO: use <nuxt-img> -->
           <img
             class="w-7 h-7 flex rounded-full text-white border-4 border-white dark:border-sky-darkest"
-            :src="'https://api.nuxtjs.org/api/ipx/s_44,f_webp/gh_avatar/' + maintainer.github"
-            :alt="maintainer.name"
+            :src="'https://api.nuxtjs.org/api/ipx/s_44,f_webp/gh_avatar/' + contributor.login"
+            :alt="contributor.name|| contributor.login"
             format="jpg"
             width="28"
             height="28"
@@ -174,9 +174,5 @@ function iconPlaceholder ({ category }: ModuleInfo) {
 
 function npmUrl ({ npm }: ModuleInfo) {
   return `https://npmjs.com/package/${npm}`
-}
-
-function githubUrl ({ github }: MaintainerInfo) {
-  return `https://github.com/${github}`
 }
 </script>

--- a/website/components/TheMain.vue
+++ b/website/components/TheMain.vue
@@ -26,8 +26,7 @@
           <!-- Stats -->
           <TheStats
             :modules="state.modules"
-            :maintainers-total="state.maintainersTotal"
-            :downloads-total="state.downloadsTotal"
+            :stats="state.stats"
           />
         </div>
       </div>

--- a/website/components/TheStats.vue
+++ b/website/components/TheStats.vue
@@ -10,7 +10,7 @@
           class="text-4xl font-black text-primary dark:text-primary leading-none sm:text-6xl"
           aria-describedby="item-1"
         >
-          {{ modules.length }}
+          {{ stats.modules }}
         </dd>
         <dt
           id="item-1"
@@ -27,7 +27,7 @@
         <dd
           class="text-4xl font-black text-primary dark:text-primary leading-none sm:text-6xl"
         >
-          {{ numberFormatter(downloadsTotal) }}
+          {{ numberFormatter(stats.downloads) }}
         </dd>
         <dt
           class="font-medium leading-6 text-sm sm:mt-2 sm:text-sm sm:capitalize"
@@ -43,12 +43,12 @@
         <dd
           class="text-4xl font-black text-primary dark:text-primary leading-none sm:text-6xl"
         >
-          {{ maintainersTotal }}
+          {{ stats.contributors }}
         </dd>
         <dt
           class="font-medium leading-6 text-sm sm:mt-2 sm:text-sm sm:capitalize"
         >
-          maintainers
+          contributors
         </dt>
       </div>
     </dl>
@@ -60,8 +60,10 @@ import { numberFormatter } from '~/utils/format'
 import { ModuleInfo } from '~/../lib/types'
 
 defineProps<{
-  modules: ModuleInfo[],
-  maintainersTotal: number,
-  downloadsTotal: number
+  stats: {
+    contributors: number,
+    downloads: number,
+    modules: number
+  }
 }>()
 </script>

--- a/website/composables/fetch.ts
+++ b/website/composables/fetch.ts
@@ -4,17 +4,6 @@ import { categories } from '~/../lib/categories'
 export async function fetchModules () {
   const { modules } = await $fetch('/api/modules') as { modules: ModuleInfo[]}
 
-  const maintainers = []
-  let downloadsTotal = 0
-  modules.forEach((module) => {
-    downloadsTotal += (module.downloads || 0)
-    module.maintainers.forEach((maintainer) => {
-      if (!maintainers.find(m => m.name === maintainer.name)) {
-        maintainers.push(maintainer)
-      }
-    })
-  })
-
   for (const module of modules) {
     // Extract compatibility tags
     // TOOD: Improve with semver checker
@@ -37,11 +26,17 @@ export async function fetchModules () {
     ] as string[]
   }
 
+  // Unique contributors
+  const contributors = new Set(modules.flatMap(m => m.contributors.map(m => m.login)))
+
   return {
     modules,
     categories,
-    maintainersTotal: maintainers.length,
-    downloadsTotal
+    stats: {
+      downloads: modules.reduce((sum, m) => sum + m.downloads, 0),
+      contributors: contributors.size,
+      modules: modules.length
+    }
   }
 }
 

--- a/website/server/api/modules.ts
+++ b/website/server/api/modules.ts
@@ -17,11 +17,20 @@ async function fetchModuleStats (module: ModuleInfo) {
   if (process.env.NODE_ENV === 'production' || process.env.USE_NUXT_API) {
     const [npm, github, contributors] = await Promise.all([
       $fetch<any>(`https://api.nuxtjs.org/api/npm/package/${module.npm}`)
-        .catch(() => ({ downloads: { lastMonth: 0 } })),
+        .catch((err) => {
+          console.error(`Cannot fetch npm info for ${module.npm}: ${err}`)
+          return { downloads: { lastMonth: 0 } }
+        }),
       $fetch<any>(`https://api.nuxtjs.org/api/github/repo/${ghRepo}`)
-        .catch(() => ({ stars: 0 })),
+        .catch((err) => {
+          console.error(`Cannot fetch github repo info for ${ghRepo}: ${err}`)
+          return { stars: 0 }
+        }),
       $fetch<any>(`https://api.nuxtjs.org/api/github/contributors/${ghRepo}`)
-        .catch(() => ([]))
+        .catch((err) => {
+          console.error(`Cannot fetch github contributors info for ${ghRepo}: ${err}`)
+          return []
+        })
     ])
     module.downloads = npm.downloads.lastMonth
     module.stars = github.stars

--- a/website/server/api/modules.ts
+++ b/website/server/api/modules.ts
@@ -13,22 +13,34 @@ function rand (min: number, max: number) {
 }
 
 async function fetchModuleStats (module: ModuleInfo) {
+  const ghRepo = module.repo.split('#')[0]
   if (process.env.NODE_ENV === 'production' || process.env.USE_NUXT_API) {
-    const [npm, github] = await Promise.all([
+    const [npm, github, contributors] = await Promise.all([
       $fetch<any>(`https://api.nuxtjs.org/api/npm/package/${module.npm}`)
         .catch(() => ({ downloads: { lastMonth: 0 } })),
-      $fetch<any>(`https://api.nuxtjs.org/api/github/repo/${module.repo.split('#')[0]}`)
-        .catch(() => ({ stars: 0 }))
+      $fetch<any>(`https://api.nuxtjs.org/api/github/repo/${ghRepo}`)
+        .catch(() => ({ stars: 0 })),
+      $fetch<any>(`https://api.nuxtjs.org/api/github/contributors/${ghRepo}`)
+        .catch(() => ([]))
     ])
     module.downloads = npm.downloads.lastMonth
     module.stars = github.stars
     module.publishedAt = +new Date(npm.publishedAt || undefined)
     module.createdAt = +new Date(npm.createdAt || undefined)
+    module.contributors = contributors
   } else {
     module.downloads = rand(0, 500)
     module.stars = rand(0, 2000)
     module.publishedAt = rand(1_600_000_000_000, 1_630_000_000_000)
     module.createdAt = rand(1_600_000_000_000, 1_630_000_000_000)
+    module.contributors = [
+      { login: 'nuxt' },
+      { login: 'vuejs' },
+      { login: 'unjs' }
+    ]
+
+    // Uncoment for real stats
+    // module.contributors = await $fetch<any>(`https://api.nuxtjs.org/api/github/contributors/${ghRepo}`)
   }
   return module
 }


### PR DESCRIPTION
Closes #253

Show top 5 github contributors of each module instead of manual maintainers array (to be removed from DB)

I've also made few refactors for `stats` object in website

Currently, api.nuxtjs.org only returns `login` without name (seems limitation of gh rest API). But name fallback is added in place to reflect when we fix API issue.

Preview: https://modules-k6y576be3-nuxt-js.vercel.app/