### PR TITLE
chore: update storybook bridge support

### DIFF
--- a/modules/storybook.yml
+++ b/modules/storybook.yml
@@ -19,4 +19,5 @@ maintainers:
     twitter: _pi0_
 compatibility:
   nuxt: ^2.0.0
-  requires: {}
+  requires:
+    bridge: optional


### PR DESCRIPTION
As of v4.2.0 Storybook supports Bridge