### PR TITLE
chore: readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Metadata of nuxt modules are maintained in [yml](https://en.wikipedia.org/wiki/Y
 
 Compiled JSON data is available from following CDNs:
 
-- **jsdelivr:**: https://cdn.jsdelivr.net/npm/@nuxt/modules@latest/modules.json
+- **jsdelivr:** https://cdn.jsdelivr.net/npm/@nuxt/modules@latest/modules.json
 - **unpkg:** https://unpkg.com/@nuxt/modules@latest/modules.json
 
 ### Using npm package
@@ -83,7 +83,7 @@ yarn sync
 
 ### Generate `npm/modules.json`
 
-```sh
+```bash
 yarn build
 ```
 


### PR DESCRIPTION
Removed an extra colon and changed from sh to bash in a code comment for consistency with the rest