### PR TITLE
fix: replaces backslashes by slashes for globby pattern in readModules

### DIFF
--- a/lib/modules.ts
+++ b/lib/modules.ts
@@ -158,7 +158,8 @@ export async function writeModule (module) {
 }
 
 export async function readModules () {
-  const names = (await globby(join(modulesDir, '*.yml'))).map(p => basename(p, extname(p))).filter(_ => _)
+  const globPattern = join(modulesDir, '*.yml').replace(/\\/g, '/')
+  const names = (await globby(globPattern)).map(p => basename(p, extname(p))).filter(_ => _)
 
   return Promise.all(names.map(n => getModule(n)))
     .then(modules => modules.filter(m => m.name))


### PR DESCRIPTION
On Windows, the readModules function did not return anything. `names` was always empty. The reason is that globby does not seem to work when the pattern contains double blackslashes.

See : https://github.com/sindresorhus/globby/issues/179