### PR TITLE
fix(footer): spacing between logos

### DIFF
--- a/website/components/TheFooter.vue
+++ b/website/components/TheFooter.vue
@@ -1,7 +1,7 @@
 <template>
   <footer class="container flex flex-col items-center justify-center pt-12 px-4 mx-auto text-stone-green">
     <p>For more information on Nuxt modules, including how to create a module, check out our <a href="https://nuxtjs.org/guides/directory-structure/modules" rel="noopener" target="_blank" class="items-center space-x-1 leading-4 border-b text-md text-grey border-stone-green hover:text-green-500 hover:border-green-600">docs</a>.</p>
-    <div class="flex justify-center px-4 pt-6 space-x-2 sm:px-0">
+    <div class="flex justify-center px-4 pt-6 gap-2 sm:px-0">
       <a href="https://vercel.com" rel="noopener" target="_blank" aria-label="go to vercel">
         <IconVercel alt="Vercel" />
       </a>


### PR DESCRIPTION
This PR replaces `space-x-2` with `gap-2` , since it's [a supported property in flexbox](https://caniuse.com/?search=gap), and fixes the spacing between the Nuxt and Vercel badges.

Before:
![image](https://user-images.githubusercontent.com/20427094/151568977-5b6f1bf7-ab3b-45d5-ae02-15b4d58af68a.png)
After:
![image](https://user-images.githubusercontent.com/20427094/151568939-df4ef958-6a99-4be5-b551-24b12720f57f.png)
