### PR TITLE
Adds missing npm key to formkit.yml

### DIFF
--- a/modules/formkit.yml
+++ b/modules/formkit.yml
@@ -1,7 +1,7 @@
 name: formkit
 description: Seamless FormKit integration for Nuxt
 repo: formkit/formkit
-npm: @formkit/nuxt
+npm: '@formkit/nuxt'
 icon: formkit.png
 github: https://github.com/formkit/formkit
 website: https://formkit.com

--- a/modules/formkit.yml
+++ b/modules/formkit.yml
@@ -1,6 +1,7 @@
 name: formkit
 description: Seamless FormKit integration for Nuxt
 repo: formkit/formkit
+npm: @formkit/nuxt
 icon: formkit.png
 github: https://github.com/formkit/formkit
 website: https://formkit.com


### PR DESCRIPTION
Noticed that the FormKit yml file was missing the `npm` key so there were no download stats showing and the link was broken. This PR fixes that. Thanks!

![Screen Shot 2022-03-09 at 11 31 34 AM](https://user-images.githubusercontent.com/2946356/157486226-70331df5-4a45-41c1-83fe-eb6cd89abb4b.jpg)
