### PR TITLE
chore: update nuxt-typed-router compatibility

### DIFF
--- a/modules/typed-router.yml
+++ b/modules/typed-router.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: victorgarciaesgi
     github: victorgarciaesgi
 compatibility:
-  nuxt: ^2.0.0
+  nuxt: ^2.0.0 || ^3.0.0
   requires: {}


### PR DESCRIPTION
[`nuxt-typed-router`](https://github.com/victorgarciaesgi/nuxt-typed-router) supports Nuxt 3 and Nuxt 2. Resolves #292.

