### PR TITLE
chore: add missing `npm` key for nuxt-graphql-client

### DIFF
--- a/modules/graphql-client.yml
+++ b/modules/graphql-client.yml
@@ -3,10 +3,11 @@ description: >-
   Minimal GraphQL Client + Code Generation for Nuxt. Auto imports GraphQL
   Operations for easy execution.
 repo: diizzayy/nuxt-graphql-client
+npm: nuxt-graphql-client
 icon: graphql-client.svg
 github: https://github.com/diizzayy/nuxt-graphql-client
 website: https://github.com/diizzayy/nuxt-graphql-client
-learn_more: https://www.graphql-code-generator.com/plugins/typescript-graphql-request
+learn_more: https://nuxt-graphql-client.web.app
 category: Request
 type: 3rd-party
 maintainers:


### PR DESCRIPTION
The missing npm property causes it to fail when fetching npm stats.