### PR TITLE
fix: update robots module

### DIFF
--- a/modules/robots.yml
+++ b/modules/robots.yml
@@ -12,5 +12,6 @@ maintainers:
   - name: Ricardo Gobbo de Souza
     github: ricardogobbosouza
 compatibility:
-  nuxt: ^2.0.0
-  requires: {}
+  nuxt: ^2.0.0 || ^3.0.0
+  requires:
+    bridge: optional


### PR DESCRIPTION
`@nuxtjs/robots` supports Nuxt 3 and Nuxt Bridge.

ref: https://github.com/nuxt-community/robots-module/pull/52