### PR TITLE
chore: fix table of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Field Name      | Auto sync | Description
 `category`      | No        | Module category from [./lib/categories.json](./lib/categories.json)
 `type`          | No        | `community` (for [nuxt-community](https://github.com/nuxt-community/)), `official` (for https://github.com/) or `3rd-party`
 `maintainers`   | Yes       | List of maintainers each item has `name`, `github` and `avatar`
-`compatibility` | No        | Module compatibility status. `nuxt` field specifies semver of supported nuxt version. `requires.bridge: true|optional` can be used to specify Nuxt 2 bridge compatibility.
+`compatibility` | No        | Module compatibility status. `nuxt` field specifies semver of supported nuxt version. `requires.bridge: true\|optional` can be used to specify Nuxt 2 bridge compatibility.
 
 
 ## Maintenance


### PR DESCRIPTION
Close #439 

The modified README can be found here.
https://github.com/odanado/modules/tree/fix-readme