### PR TITLE
fix: skip image proxy for svg icons

### DIFF
--- a/website/components/CardModule.vue
+++ b/website/components/CardModule.vue
@@ -23,7 +23,7 @@
         <!-- TODO: use <nuxt-img> -->
         <img
           v-if="!coverError && iconUrl(mod)"
-          :src="'https://api.nuxtjs.org/api/ipx/s_80,f_webp/gh/nuxt/modules/main/website/public/' + iconUrl(mod)"
+          :src="iconUrl(mod).endsWith('.svg') ? iconUrl(mod) : 'https://api.nuxtjs.org/api/ipx/s_80,f_webp/gh/nuxt/modules/main/website/public/' + iconUrl(mod)"
           :alt="mod.name"
           class="w-10 h-10 object-contain"
           width="40px"


### PR DESCRIPTION
**Before**:

<img width="614" alt="CleanShot 2022-10-25 at 18 25 21@2x" src="https://user-images.githubusercontent.com/28706372/197830012-b64ae366-9ae9-4ca1-9dfb-e66ac0b200f6.png">

**After**:

<img width="623" alt="CleanShot 2022-10-25 at 18 26 01@2x" src="https://user-images.githubusercontent.com/28706372/197830024-8ab4a42f-c182-40f3-9ce7-13197fd94b1c.png">

