### PR TITLE
feat: add `nuxt-simple-robots`

### DIFF
--- a/modules/simple-robots.yml
+++ b/modules/simple-robots.yml
@@ -1,0 +1,18 @@
+name: simple-robots
+repo: harlan-zw/nuxt-simple-robots
+npm: nuxt-simple-robots
+description: Simply manage the robots crawling your Nuxt app.
+icon: ''
+github: https://github.com/harlan-zw/nuxt-simple-robots
+website: https://github.com/harlan-zw/nuxt-simple-robots
+learn_more: ''
+category: SEO
+type: 3rd-party
+maintainers:
+  - name: Harlan Wilton
+    github: harlan-zw
+    twitter: harlan_zw
+    avatar: https://avatars.githubusercontent.com/harlan-zw?v=4
+compatibility:
+  nuxt: ^3.0.0
+  requires: {}


### PR DESCRIPTION
While there is https://github.com/nuxt-community/robots-module, I find the module doesn't have a nice DX. Its scope is minimal in that it only creates a robots.txt, where it also makes sense to add the HTTP header and meta tags when routes should be blocked.

It also has the benefits of:
- nitro route rules to manage the indexable routes (more nuxt 3)
- blocks `'/_nuxt/*'` by default
- provides more SEO friendly default robots value when can be indexed
- will automatically block non-production apps from being indexed 