### PR TITLE
feat: update snipcart module configuration

### DIFF
--- a/modules/snipcart.yml
+++ b/modules/snipcart.yml
@@ -5,13 +5,13 @@ npm: '@nuxtjs/snipcart'
 icon: snipcart.png
 github: https://github.com/nuxt-community/snipcart-module
 website: https://github.com/nuxt-community/snipcart-module
-learn_more: ''
+learn_more: https://github.com/nuxt-modules/snipcart
 category: Payment
 type: community
 maintainers:
   - name: Florent GIRAUD
-    github: f3ltron
-    twitter: giraud_florent
+    github: flozero
+    twitter: flozeroo
 compatibility:
-  nuxt: ^2.0.0
+  nuxt: ^3.0.0
   requires: {}


### PR DESCRIPTION
close #572

Just want to make sure I understand what we want here. 

The main module 2.x is supporting nuxt I didn't take time to check if it is compatible for nuxt 2. But nuxt 2 I wrote in my doc people can use 1.x.

I put here nuxt 3 tell me if this needs to change or not @danielroe. It was the only thing you were expected right ? I don't see anything else in the doc https://github.com/nuxt/modules#addupdate-a-module

And thanks again for the help