### PR TITLE
fix: correct vue-email repo subpath

### DIFF
--- a/modules/vue-email.yml
+++ b/modules/vue-email.yml
@@ -1,7 +1,7 @@
 name: vue-email
 description: Write email templates with vue
-repo: Dave136/vue-email
-npm: root
+repo: Dave136/vue-email#main/packages/vue-email
+npm: 'vue-email'
 icon: vue-email.svg
 github: https://github.com/Dave136/vue-email#main/packages/vue-email
 website: https://vue-email.vercel.app/

--- a/modules/vue-email.yml
+++ b/modules/vue-email.yml
@@ -1,7 +1,7 @@
 name: vue-email
 description: Write email templates with vue
 repo: Dave136/vue-email
-npm: 'vue-email'
+npm: root
 icon: vue-email.svg
 github: https://github.com/Dave136/vue-email#main/packages/vue-email
 website: https://vue-email.vercel.app/

--- a/modules/vue-email.yml
+++ b/modules/vue-email.yml
@@ -1,7 +1,7 @@
 name: vue-email
 description: Write email templates with vue
 repo: Dave136/vue-email
-npm: root
+npm: 'vue-email'
 icon: vue-email.svg
 github: https://github.com/Dave136/vue-email#main/packages/vue-email
 website: https://vue-email.vercel.app/


### PR DESCRIPTION
@danielroe sorry to bother you, but it seems that the name was updated when the previous PR was merged, as its says root now in the website, i types the name correctly when i pushed, but somehow it got changed
![image](https://github.com/nuxt/modules/assets/35883748/d03ab080-9943-4f54-a63e-5e1c070a2513)
