### PR TITLE
fix: vue-query is a monorepo

### DIFF
--- a/modules/vue-query.yml
+++ b/modules/vue-query.yml
@@ -1,6 +1,6 @@
 name: vue-query
 description: 0 config lightweight Nuxt module for @tanstack/vue-query.
-repo: Hebilicious/vue-query-nuxt#main
+repo: Hebilicious/vue-query-nuxt/packages/vue-query-nuxt#main
 npm: '@hebilicious/vue-query-nuxt'
 icon: vue-query.svg
 github: https://github.com/Hebilicious/vue-query-nuxt


### PR DESCRIPTION
This should correctly reference the package.json and display the missing informations on the website. 