### PR TITLE
fix: use new documentation website url

### DIFF
--- a/modules/nuxt-vue3-google-signin.yml
+++ b/modules/nuxt-vue3-google-signin.yml
@@ -1,11 +1,11 @@
 name: nuxt-vue3-google-signin
 description: Empower your Nuxt app with Google Sign-In, hassle-free
-repo: syetalabs/nuxt-vue3-google-signin
+repo: wavezync/nuxt-vue3-google-signin
 npm: nuxt-vue3-google-signin
 icon: vue3-google-signin.svg
-github: https://github.com/syetalabs/nuxt-vue3-google-signin
-website: https://vue3-google-signin.syetalabs.io
-learn_more: https://vue3-google-signin.syetalabs.io
+github: https://github.com/wavezync/nuxt-vue3-google-signin
+website: https://vue3-google-signin.wavezync.com
+learn_more: https://vue3-google-signin.wavezync.com
 category: Libraries
 type: 3rd-party
 maintainers:


### PR DESCRIPTION
We have moved the repo to a new organization called WaveZync. We will use a new documentation website representing the new organization


# In this PR
- Adds the latest URL for vue3-google-signin documentation website