### PR TITLE
fix: direct pinia-plugin-persistedstate repo link to nuxt package

### DIFF
--- a/modules/pinia-plugin-persistedstate.yml
+++ b/modules/pinia-plugin-persistedstate.yml
@@ -1,6 +1,6 @@
 name: pinia-plugin-persistedstate
 description: Configurable persistence and rehydration of Pinia stores.
-repo: prazdevs/pinia-plugin-persistedstate#main/packages/nuxt
+repo: prazdevs/pinia-plugin-persistedstate/tree/main/packages/nuxt
 npm: '@pinia-plugin-persistedstate/nuxt'
 icon: pinia-plugin-persistedstate.png
 github: >-


### PR DESCRIPTION
The quickstart docs displayed on the nuxt modules page is the normal plugin docs instead of the nuxt module one. 