### PR TITLE
feat: support compatibility version map (for image)

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,9 @@ import type { categories } from './categories'
 // TODO: Support version matrix
 export interface ModuleCompatibility {
  nuxt: string
+ versionMap: {
+  [nuxtVersion: string]: string
+ }
  requires: { bridge?: boolean | 'optional' },
 }
 

--- a/modules/image.yml
+++ b/modules/image.yml
@@ -27,3 +27,6 @@ compatibility:
   nuxt: ^2.0.0 || ^3.0.0
   requires:
     bridge: optional
+  versionMap:
+    ^2.0.0: latest
+    ^3.0.0: rc

--- a/modules/image.yml
+++ b/modules/image.yml
@@ -28,5 +28,5 @@ compatibility:
   requires:
     bridge: optional
   versionMap:
-    ^2.0.0: latest
-    ^3.0.0: rc
+    2.x: latest
+    3.x: rc


### PR DESCRIPTION
(context: followup for https://github.com/nuxt/cli/pull/197)

Some Nuxt modules use different major versions for Nuxt compatibility. 

This PR adds a new standard `compatibility.versionMap` (better names welcome) to support mapping compatible Nuxt version to their Corresponding Module compatible version/tag.