### PR TITLE
chore: update tiptap documentation URL

### DIFF
--- a/modules/tiptap.yml
+++ b/modules/tiptap.yml
@@ -4,8 +4,8 @@ repo: modbender/nuxt-tiptap-editor
 npm: nuxt-tiptap-editor
 icon: tiptap.png
 github: https://github.com/modbender/nuxt-tiptap-editor
-website: https://github.com/modbender/nuxt-tiptap-editor
-learn_more: https://github.com/modbender/nuxt-tiptap-editor
+website: https://nuxt-tiptap-editor.vercel.app
+learn_more: https://nuxt-tiptap-editor.vercel.app
 category: Libraries
 type: 3rd-party
 maintainers:


### PR DESCRIPTION
- Created a documentation using vitepress and deployed
- Updated documentation URL

https://nuxt-tiptap-editor.vercel.app/