### PR TITLE
fix: update link nuxt-vcalendar

### DIFF
--- a/modules/vcalendar.yml
+++ b/modules/vcalendar.yml
@@ -3,8 +3,8 @@ description: VCalendar module for Nuxt
 repo: samk-dev/nuxt-vcalendar
 npm: '@samk-dev/nuxt-vcalendar'
 icon: vcalendar.png
-github: https://github.com/samk-dev/vcalendar
-website: https://github.com/samk-dev/vcalendar
+github: https://github.com/samk-dev/nuxt-vcalendar
+website: https://github.com/samk-dev/nuxt-vcalendar
 learn_more: ''
 category: Libraries
 type: 3rd-party


### PR DESCRIPTION
Hello team nuxt,

Apparently the old vcalendar link is not available, I think it had an update, I took the trouble to modify it... Thanks for reading.

**before**: 

https://github.com/samk-dev/vcalendar

![image](https://github.com/nuxt/modules/assets/116913262/045e4e43-9e1d-4769-a1c2-4bf0f2f24550)


**after**: 

https://github.com/samk-dev/nuxt-vcalendar

![image](https://github.com/nuxt/modules/assets/116913262/58330757-4f1f-43b0-b91e-8ad6fc47352d)
