### PR TITLE
fix: use `Analytics` category for Plausible module

### DIFF
--- a/modules/plausible.yml
+++ b/modules/plausible.yml
@@ -6,7 +6,7 @@ icon: plausible.svg
 github: https://github.com/nuxt-modules/plausible
 website: https://github.com/nuxt-modules/plausible
 learn_more: ''
-category: Devtools
+category: Analytics
 type: community
 maintainers:
   - name: Johann Schopplich


### PR DESCRIPTION
Just a little edito to place "Plausible Analytics" in the `Analytics` category, instead of the current `Devtools`