### PR TITLE
chore(ci): update deps in autofix-ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -21,4 +21,4 @@ jobs:
       - run: pnpm install
       - name: Run sync
         run: npm run sync
-      - uses: autofix-ci/action@8bc06253bec489732e5f9c52884c7cace15c0160
+      - uses: autofix-ci/action@ea32e3a12414e6d3183163c3424a7d7a8631ad84


### PR DESCRIPTION
### 🔗 Linked issue

closed #690   .
 
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The following warning was observed when running CI. It seems that the hash of autofix-ci is old.

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: autofix-ci/action@8bc06253bec489732e5f9c52884c7cace15c0160. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

#690 is a related PR, but this is an old Renovate PR.

#### 🗒️ Note

I checked Nuxt organization, Nuxt Modules organization, but all other autofix-ci were the latest commit hash.
Therefore, this repo is the only one that has a warning.

- https://github.com/search?q=org%3Anuxt%20autofix-ci%2Faction%40&type=code
- https://github.com/search?q=org%3Anuxt-modules%20autofix-ci%2Faction%40&type=code