### PR TITLE
fix: update nuxt v3 constraint to include v4 as well

### DIFF
--- a/modules/algolia.yml
+++ b/modules/algolia.yml
@@ -16,6 +16,6 @@ maintainers:
     github: yassilah
     avatar: https://avatars.githubusercontent.com/u/13403295?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true

--- a/modules/animejs.yml
+++ b/modules/animejs.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: ivodolenc
     github: ivodolenc
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/ant-design-vue.yml
+++ b/modules/ant-design-vue.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: tangjinzhou
     github: tangjinzhou
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     bridge: optional

--- a/modules/aos.yml
+++ b/modules/aos.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: egidiusmengelberg
     github: egidiusmengelberg
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/api-party.yml
+++ b/modules/api-party.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: jschopplich
     avatar: https://avatars.githubusercontent.com/johannschopplich?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/api-shield.yml
+++ b/modules/api-shield.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: rrd
     github: rrd108
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/apollo.yml
+++ b/modules/apollo.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: diizzayy
     avatar: https://avatars.githubusercontent.com/diizzayy?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/appwrite.yml
+++ b/modules/appwrite.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Hrdtr
     github: Hrdtr
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/arco-design-nuxt-module.yml
+++ b/modules/arco-design-nuxt-module.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: wiidede
     github: wiidede
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/ark-ui.yml
+++ b/modules/ark-ui.yml
@@ -15,5 +15,5 @@ maintainers:
     github: iamdin
     twitter: iamdinq
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/auth-utils.yml
+++ b/modules/auth-utils.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: atinux
     github: atinux
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/authjs.yml
+++ b/modules/authjs.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Hebilicious
     twitter: its_hebilicious
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/authorization.yml
+++ b/modules/authorization.yml
@@ -13,5 +13,5 @@ maintainers:
     github: barbapapazes
     twitter: soubiran_
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/auto-animate.yml
+++ b/modules/auto-animate.yml
@@ -13,5 +13,5 @@ maintainers:
     github: justin-schroeder
     twitter: jpschroeder
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/bugsnag.yml
+++ b/modules/bugsnag.yml
@@ -15,6 +15,6 @@ maintainers:
     github: JulianMar
     twitter: julian_martin96
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true

--- a/modules/calendly.yml
+++ b/modules/calendly.yml
@@ -16,5 +16,5 @@ maintainers:
     github: madebyfabian
     twitter: madebyfabian
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/capo.yml
+++ b/modules/capo.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: danielroe
     github: danielroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/chatwoot.yml
+++ b/modules/chatwoot.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: productdevbook
     github: productdevbook
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/clarity-analytics.yml
+++ b/modules/clarity-analytics.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Barbapapazes
     twitter: soubiran_
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/cloudflare-analytics.yml
+++ b/modules/cloudflare-analytics.yml
@@ -15,5 +15,5 @@ maintainers:
     github: madebyfabian
     twitter: madebyfabian
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/color-mode.yml
+++ b/modules/color-mode.yml
@@ -13,6 +13,6 @@ maintainers:
     github: Atinux
     twitter: Atinux
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/content-assets.yml
+++ b/modules/content-assets.yml
@@ -13,5 +13,5 @@ maintainers:
     github: davestewart
     twitter: dave_stewart
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/content.yml
+++ b/modules/content.yml
@@ -22,5 +22,5 @@ maintainers:
     github: Atinux
     twitter: Atinux
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/cookie-control.yml
+++ b/modules/cookie-control.yml
@@ -13,5 +13,5 @@ maintainers:
     github: dargmuesli
     avatar: https://avatars.githubusercontent.com/dargmuesli
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/csurf.yml
+++ b/modules/csurf.yml
@@ -13,5 +13,5 @@ maintainers:
     github: morgbn
     avatar: https://avatars.githubusercontent.com/u/25689856?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/datocms.yml
+++ b/modules/datocms.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: jamiewarb
     avatar: https://avatars.githubusercontent.com/jamiewarb?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/dayjs.yml
+++ b/modules/dayjs.yml
@@ -13,5 +13,5 @@ maintainers:
     github: acidjazz
     twitter: AppFume
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/delay-hydration.yml
+++ b/modules/delay-hydration.yml
@@ -13,5 +13,5 @@ maintainers:
     github: harlan-zw
     twitter: harlan_zw
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/device.yml
+++ b/modules/device.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Shinji Yamada
     github: dotneet
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/devtools.yml
+++ b/modules/devtools.yml
@@ -15,5 +15,5 @@ maintainers:
     github: antfu
     twitter: antfu7
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/directus.yml
+++ b/modules/directus.yml
@@ -13,6 +13,6 @@ maintainers:
     github: intevel
     avatar: https://avatars.githubusercontent.com/u/59223342?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/disqus.yml
+++ b/modules/disqus.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: modbender
     github: modbender
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/doppler.yml
+++ b/modules/doppler.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: JamieCurnow
     github: JamieCurnow
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/drupal-ce.yml
+++ b/modules/drupal-ce.yml
@@ -19,5 +19,5 @@ maintainers:
     github: TurtlBbx
     avatar: https://avatars.githubusercontent.com/u/29594309?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/easy-lightbox.yml
+++ b/modules/easy-lightbox.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: modbender
     github: modbender
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/echarts.yml
+++ b/modules/echarts.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Yue JIN
     github: kingyue737
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/edgedb.yml
+++ b/modules/edgedb.yml
@@ -15,5 +15,5 @@ maintainers:
     github: Tahul
     twitter: yaeeelglx
 compatibility:
-  nuxt: ^3.8.0
+  nuxt: '>=3.8.0'
   requires: {}

--- a/modules/electron.yml
+++ b/modules/electron.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: 草鞋没号
     github: caoxiemeihao
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/element-plus.yml
+++ b/modules/element-plus.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: tolking
     github: tolking
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     bridge: optional

--- a/modules/emotion.yml
+++ b/modules/emotion.yml
@@ -16,5 +16,5 @@ maintainers:
     github: codebender828
     twitter: codebender828
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/eslint-module.yml
+++ b/modules/eslint-module.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Ricardo Gobbo de Souza
     github: ricardogobbosouza
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/eslint.yml
+++ b/modules/eslint.yml
@@ -15,5 +15,5 @@ maintainers:
     github: antfu
     twitter: antfu7
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/fathom-analytics.yml
+++ b/modules/fathom-analytics.yml
@@ -13,5 +13,5 @@ maintainers:
     github: valgeirb
     avatar: https://avatars.githubusercontent.com/valgeirb
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/flags.yaml
+++ b/modules/flags.yaml
@@ -13,4 +13,4 @@ maintainers:
     github: conejerock
     twitter: juanjoconejero
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'

--- a/modules/fontaine.yml
+++ b/modules/fontaine.yml
@@ -13,5 +13,5 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/fonts.yml
+++ b/modules/fonts.yml
@@ -13,5 +13,5 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/form-actions.yml
+++ b/modules/form-actions.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Hebilicious
     twitter: its_hebilicious
 compatibility:
-  nuxt: ^3.7.0
+  nuxt: '>=3.7.0'
   requires: {}

--- a/modules/formkit.yml
+++ b/modules/formkit.yml
@@ -16,5 +16,5 @@ maintainers:
     github: andrew-boyd
     twitter: 0xBOYD
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/google-adsense.yml
+++ b/modules/google-adsense.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Troy Morehouse
     github: tmorehouse
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/google-fonts.yml
+++ b/modules/google-fonts.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: Ricardo Gobbo de Souza
     github: ricardogobbosouza
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/graphql-client.yml
+++ b/modules/graphql-client.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Diizzayy
     github: diizzayy
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/graphql-request.yml
+++ b/modules/graphql-request.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: gomah
     github: gomah
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/graphql-server.yml
+++ b/modules/graphql-server.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: tobiasdiez
     github: tobiasdiez
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/gtag.yml
+++ b/modules/gtag.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: jschopplich
     avatar: https://avatars.githubusercontent.com/johannschopplich?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/hanko.yml
+++ b/modules/hanko.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: danielroe
     github: danielroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/harlem.yml
+++ b/modules/harlem.yml
@@ -15,5 +15,5 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/headlessui.yml
+++ b/modules/headlessui.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Pascal Sthamer
     github: P4sca1
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/hotjar.yml
+++ b/modules/hotjar.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Raphaël DAMEVIN
     github: damevin
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/html-validator.yml
+++ b/modules/html-validator.yml
@@ -13,6 +13,6 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/hub.yml
+++ b/modules/hub.yml
@@ -20,5 +20,5 @@ maintainers:
   - name: NuxtLabs
     github: nuxtlabs
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/i18n.yml
+++ b/modules/i18n.yml
@@ -18,5 +18,5 @@ maintainers:
   - name: Bobbie Goede
     github: BobbieGoede
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/icon-font.yml
+++ b/modules/icon-font.yml
@@ -15,5 +15,5 @@ maintainers:
   - name: coremyslo
     github: coremyslo
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/icon-tw.yml
+++ b/modules/icon-tw.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: JohnCampionJr
     github: JohnCampionJr
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/icon.yml
+++ b/modules/icon.yml
@@ -14,6 +14,6 @@ maintainers:
   - name: Anthony Fu
     github: antfu
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/icons.yml
+++ b/modules/icons.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Sebastian Wludzik
     github: gitfoxcode
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/image.yml
+++ b/modules/image.yml
@@ -24,6 +24,6 @@ maintainers:
     github: Atinux
     twitter: Atinux
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/inkline.yml
+++ b/modules/inkline.yml
@@ -15,6 +15,6 @@ maintainers:
     github: alexgrozav
     twitter: alexgrozav
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true

--- a/modules/ionic.yml
+++ b/modules/ionic.yml
@@ -13,5 +13,5 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/jsonapi.yml
+++ b/modules/jsonapi.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Patrick Cate
     github: patrickcate
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/kinde.yml
+++ b/modules/kinde.yml
@@ -15,6 +15,6 @@ maintainers:
     github: DaveOrDead
     twitter: dave_or_dead
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
 sponsor: true

--- a/modules/kql.yml
+++ b/modules/kql.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: jschopplich
     avatar: https://avatars.githubusercontent.com/johannschopplich?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/laravel-precognition.yml
+++ b/modules/laravel-precognition.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: sot1986
     github: sot1986
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/link-checker.yml
+++ b/modules/link-checker.yml
@@ -14,6 +14,6 @@ maintainers:
     twitter: harlan_zw
     avatar: https://avatars.githubusercontent.com/harlan-zw?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/locomotive-scroll.yml
+++ b/modules/locomotive-scroll.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Arash Sheyda
     github: arashsheyda
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/lodash.yml
+++ b/modules/lodash.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Michal Čípa
     github: cipami
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/logrocket.yml
+++ b/modules/logrocket.yml
@@ -13,5 +13,5 @@ maintainers:
     github: farzadso
     twitter: farzadso
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/logto.yml
+++ b/modules/logto.yml
@@ -13,6 +13,6 @@ maintainers:
     github: logto-io
     twitter: logto_io
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
 sponsor: true

--- a/modules/lucide-icons.yml
+++ b/modules/lucide-icons.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Jasper Zonneveld
     github: JaZo
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/magic-regexp.yml
+++ b/modules/magic-regexp.yml
@@ -13,5 +13,5 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/mailpit.yml
+++ b/modules/mailpit.yml
@@ -13,5 +13,5 @@ maintainers:
     github: tdolsen
     twitter: tdolsen
 compatibility:
-  nuxt: ^3.8.0
+  nuxt: '>=3.8.0'
   requires: {}

--- a/modules/marquee.yml
+++ b/modules/marquee.yml
@@ -15,6 +15,6 @@ maintainers:
     github: hanzydev
     avatar: https://avatars.githubusercontent.com/u/77491112?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/maz-ui.yml
+++ b/modules/maz-ui.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Loïc Mazuel
     github: LouisMazel
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/mdc.yml
+++ b/modules/mdc.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: farnabaz
     github: farnabaz
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/medusa.yml
+++ b/modules/medusa.yml
@@ -13,6 +13,6 @@ maintainers:
     github: Baroshem
     avatar: https://avatars.githubusercontent.com/u/37120330?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true

--- a/modules/meilisearch.yml
+++ b/modules/meilisearch.yml
@@ -13,7 +13,7 @@ maintainers:
     github: xlanex6
     avatar: https://avatars.githubusercontent.com/u/13418668?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     bridge: false
   devtools: ^0.0.0

--- a/modules/module-feed.yml
+++ b/modules/module-feed.yml
@@ -13,5 +13,5 @@ maintainers:
     github: tresko
     twitter: mihasedej
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/mojocss.yml
+++ b/modules/mojocss.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: mojocss
     github: mojocss
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/neo4j.yml
+++ b/modules/neo4j.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: arashsheyda
     github: arashsheyda
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/ngrok.yml
+++ b/modules/ngrok.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Arash Sheyda
     github: arashsheyda
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nodemailer.yml
+++ b/modules/nodemailer.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: kleinpetr
     github: kleinpetr
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nupolyon.yml
+++ b/modules/nupolyon.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: adenvt
     github: adenvt
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-anchorscroll.yml
+++ b/modules/nuxt-anchorscroll.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Helltraitor
     github: helltraitor
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-asciidoc.yml
+++ b/modules/nuxt-asciidoc.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Chris2011
     twitter: Chrizzly42
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-auth-sanctum.yml
+++ b/modules/nuxt-auth-sanctum.yml
@@ -13,5 +13,5 @@ maintainers:
     github: manchenkoff
     avatar: https://avatars.githubusercontent.com/manchenkoff
 compatibility:
-  nuxt: ^3.9.0
+  nuxt: '>=3.9.0'
   requires: {}

--- a/modules/nuxt-basic-auth.yml
+++ b/modules/nuxt-basic-auth.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: kgierke
     github: kgierke
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-bezier.yml
+++ b/modules/nuxt-bezier.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Soryn Gitlan
     github: 50rayn
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-booster.yml
+++ b/modules/nuxt-booster.yml
@@ -18,6 +18,6 @@ maintainers:
     github: StephanGerbeth
     avatar: https://avatars.githubusercontent.com/u/3775511?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/nuxt-bootstrap-icons.yml
+++ b/modules/nuxt-bootstrap-icons.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: OyewoleOyedeji
     github: OyewoleOyedeji
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-chatgpt.yml
+++ b/modules/nuxt-chatgpt.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Oliver Trajceski
     github: schnapsterdog
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-cookie-consent.yml
+++ b/modules/nuxt-cookie-consent.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: weareheavy
     github: weareheavy
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-facebook-chat.yml
+++ b/modules/nuxt-facebook-chat.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: superdev-tech
     github: superdev-tech
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-feather-icons.yml
+++ b/modules/nuxt-feather-icons.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: 4sllan
     github: 4sllan
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-feedme.yml
+++ b/modules/nuxt-feedme.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Helltraitor
     github: helltraitor
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-file-storage.yml
+++ b/modules/nuxt-file-storage.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: NyllRE
     github: NyllRE
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-fontawesome.yml
+++ b/modules/nuxt-fontawesome.yml
@@ -13,5 +13,5 @@ maintainers:
     github: bezumkin
     avatar: https://avatars.githubusercontent.com/u/1257284
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-graphql-middleware.yml
+++ b/modules/nuxt-graphql-middleware.yml
@@ -17,5 +17,5 @@ maintainers:
     github: ayalon
     avatar: https://avatars.githubusercontent.com/ayalon?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/nuxt-gtm.yml
+++ b/modules/nuxt-gtm.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: Zadig&Voltaire Team
     github: zadigetvoltaire
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/nuxt-hue.yml
+++ b/modules/nuxt-hue.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: lihbr
     github: lihbr
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/nuxt-jsonld.yml
+++ b/modules/nuxt-jsonld.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: ymmooot
     github: ymmooot
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-localtunnel.yml
+++ b/modules/nuxt-localtunnel.yml
@@ -13,5 +13,5 @@ maintainers:
     github: craigharman
     twitter: craig_harman
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-loco.yml
+++ b/modules/nuxt-loco.yml
@@ -13,5 +13,5 @@ maintainers:
     github: gaetansenn
     avatar: https://avatars.githubusercontent.com/u/2774075?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-mail.yml
+++ b/modules/nuxt-mail.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Sebastian Landwehr
     github: dword-design
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/nuxt-mapbox.yml
+++ b/modules/nuxt-mapbox.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Alex Lavoie
     github: AlexLavoie42
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-mdi.yml
+++ b/modules/nuxt-mdi.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Emil Rosenius
     github: ERPedersen
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-meta-pixel.yml
+++ b/modules/nuxt-meta-pixel.yml
@@ -15,5 +15,5 @@ maintainers:
     github: tanukijs
     avatar: https://avatars.githubusercontent.com/u/25182349?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-monaco-editor.yml
+++ b/modules/nuxt-monaco-editor.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: e-chan1007
     github: e-chan1007
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-mongoose.yml
+++ b/modules/nuxt-mongoose.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: arashsheyda
     github: arashsheyda
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/nuxt-oidc-auth.yml
+++ b/modules/nuxt-oidc-auth.yml
@@ -15,5 +15,5 @@ maintainers:
     github: itpropro
     twitter: jandamaschke
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-openapi-docs-module.yml
+++ b/modules/nuxt-openapi-docs-module.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Pavel Kuzmin
     github: s00d
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-openid-connect.yml
+++ b/modules/nuxt-openid-connect.yml
@@ -14,6 +14,6 @@ maintainers:
   - name: Khaled Almana
     github: KhaledAlMana
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/nuxt-payload-analyzer.yml
+++ b/modules/nuxt-payload-analyzer.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Barbapapazes
     twitter: soubiran_
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-pdf-frame.yml
+++ b/modules/nuxt-pdf-frame.yml
@@ -13,5 +13,5 @@ maintainers:
     github: nswamy14
     email: narayanaswamy14@gmail.com
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-pdf.yml
+++ b/modules/nuxt-pdf.yml
@@ -13,5 +13,5 @@ maintainers:
     github: sidebase
     twitter: sidebase_io
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-phosphor-icons.yml
+++ b/modules/nuxt-phosphor-icons.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: OyewoleOyedeji
     github: OyewoleOyedeji
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-plotly.yml
+++ b/modules/nuxt-plotly.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: superdev-tech
     github: superdev-tech
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-posthog.yml
+++ b/modules/nuxt-posthog.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Carles Mitjans
     github: mitjans
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-social-share.yml
+++ b/modules/nuxt-social-share.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: stefanobartoletti
     github: stefanobartoletti
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-ssr-lit.yml
+++ b/modules/nuxt-ssr-lit.yml
@@ -16,5 +16,5 @@ maintainers:
     github: steveworkman
     twitter: steveworkman
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-svgo-loader.yml
+++ b/modules/nuxt-svgo-loader.yml
@@ -13,6 +13,6 @@ maintainers:
     github: Mini-ghost
     twitter: Minighost_Alex
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/nuxt-svgo.yml
+++ b/modules/nuxt-svgo.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: cpsoinos
     github: cpsoinos
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-uswds.yml
+++ b/modules/nuxt-uswds.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Patrick Cate
     github: patrickcate
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-viewport.yml
+++ b/modules/nuxt-viewport.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: mvrlin
     github: mvrlin
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/nuxt-vue3-google-signin.yml
+++ b/modules/nuxt-vue3-google-signin.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Kasun Vithanage
     github: kasvith
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt-zod-i18n.yml
+++ b/modules/nuxt-zod-i18n.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: xibman
     github: xibman
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt3-interpolation.yml
+++ b/modules/nuxt3-interpolation.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: daliborgogic
     github: daliborgogic
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/nuxt3-leaflet.yml
+++ b/modules/nuxt3-leaflet.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Augustin MERCIER
     github: Gugustinette
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/og-image.yml
+++ b/modules/og-image.yml
@@ -14,6 +14,6 @@ maintainers:
     twitter: harlan_zw
     avatar: https://avatars.githubusercontent.com/harlan-zw?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/onyx.yml
+++ b/modules/onyx.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Schwarz IT
     github: SchwarzIT
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/particles.yml
+++ b/modules/particles.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Joepocalyptic
     avatar: https://avatars.githubusercontent.com/Joepocalyptic?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/partytown.yml
+++ b/modules/partytown.yml
@@ -15,6 +15,6 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true

--- a/modules/paypal.yml
+++ b/modules/paypal.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Arash Sheyda
     github: arashsheyda
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/pdfeasy.yml
+++ b/modules/pdfeasy.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: novoutttttt
     avatar: https://avatars.githubusercontent.com/novout?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/pergel.yml
+++ b/modules/pergel.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Mehmet - productdevbook
     github: productdevbook
 compatibility:
-  nuxt: ^3.10.0
+  nuxt: '>=3.10.0'
   requires: {}

--- a/modules/pinia-orm.yml
+++ b/modules/pinia-orm.yml
@@ -14,6 +14,6 @@ maintainers:
   - name: CodeDredd
     github: CodeDredd
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/pinia-plugin-persistedstate.yml
+++ b/modules/pinia-plugin-persistedstate.yml
@@ -13,6 +13,6 @@ maintainers:
   - name: PraZ
     github: prazdevs
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/pinia.yml
+++ b/modules/pinia.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: posva
     github: posva
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/plausible.yml
+++ b/modules/plausible.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Johann Schopplich
     github: johannschopplich
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/prepare.yml
+++ b/modules/prepare.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: jschopplich
     avatar: https://avatars.githubusercontent.com/johannschopplich?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/primevue.yml
+++ b/modules/primevue.yml
@@ -13,5 +13,5 @@ maintainers:
     github: primefaces
     twitter: primevue
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/prisma.yml
+++ b/modules/prisma.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: prisma
     github: prisma
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/prismic.yml
+++ b/modules/prismic.yml
@@ -13,5 +13,5 @@ maintainers:
     github: lihbr
     twitter: li_hbr
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/prometheus.yml
+++ b/modules/prometheus.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: artmizu
     github: artmizu
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/purgecss.yml
+++ b/modules/purgecss.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Developmint
     github: Developmint
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/quasar.yml
+++ b/modules/quasar.yml
@@ -14,6 +14,6 @@ maintainers:
   - name: Ege İliklier
     github: Maiquu
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/radash.yml
+++ b/modules/radash.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Batuhan Göksu
     github: bbg
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/radix-vue.yml
+++ b/modules/radix-vue.yml
@@ -21,5 +21,5 @@ maintainers:
   - name: Max
     github: onmax
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/resend.yml
+++ b/modules/resend.yml
@@ -13,5 +13,5 @@ maintainers:
     github: nhedger
     twitter: nicolashedger
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/robots.yml
+++ b/modules/robots.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: Ricardo Gobbo de Souza
     github: ricardogobbosouza
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/rollbar.yml
+++ b/modules/rollbar.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Jairo Blatt
     github: jairoblatt
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/sanity.yml
+++ b/modules/sanity.yml
@@ -13,6 +13,6 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/scalar.yml
+++ b/modules/scalar.yml
@@ -13,5 +13,5 @@ maintainers:
     github: scalar
     twitter: scalar
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/schema-org.yml
+++ b/modules/schema-org.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: harlan_zw
     avatar: https://avatars.githubusercontent.com/harlan-zw?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/scripts.yml
+++ b/modules/scripts.yml
@@ -13,5 +13,5 @@ maintainers:
     github: harlan-zw
     twitter: harlan_zw
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/security.yml
+++ b/modules/security.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Baroshem
     avatar: https://avatars.githubusercontent.com/u/37120330?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/seo-experiments.yml
+++ b/modules/seo-experiments.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: harlan_zw
     avatar: https://avatars.githubusercontent.com/harlan-zw?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/seo.yml
+++ b/modules/seo.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: harlan-zw
     github: harlan-zw
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/server-block.yml
+++ b/modules/server-block.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Hebilicious
     twitter: its_hebilicious
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/shadcn.yml
+++ b/modules/shadcn.yml
@@ -15,5 +15,5 @@ maintainers:
   - name: Sadegh Barati
     github: sadeghbarati
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/shuimo-ui.yml
+++ b/modules/shuimo-ui.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: higuaifan
     github: higuaifan
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/sidebase-auth.yml
+++ b/modules/sidebase-auth.yml
@@ -16,5 +16,5 @@ maintainers:
     github: sidebase
     twitter: sidebase_io
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/simple-robots.yml
+++ b/modules/simple-robots.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: harlan_zw
     avatar: https://avatars.githubusercontent.com/harlan-zw?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/sitemap.yml
+++ b/modules/sitemap.yml
@@ -17,5 +17,5 @@ maintainers:
     github: NicoPennec
     twitter: NicoPennec
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/snackbar.yml
+++ b/modules/snackbar.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: modbender
     github: modbender
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/snipcart.yml
+++ b/modules/snipcart.yml
@@ -13,5 +13,5 @@ maintainers:
     github: flozero
     twitter: flozeroo
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/storefront-ui.yml
+++ b/modules/storefront-ui.yml
@@ -16,5 +16,5 @@ maintainers:
     github: FRSgit
     avatar: https://avatars.githubusercontent.com/u/10456649?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/storyblok.yml
+++ b/modules/storyblok.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: storyblok
     github: storyblok
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}
   devtools: ^0.0.0

--- a/modules/storybook.yml
+++ b/modules/storybook.yml
@@ -15,7 +15,7 @@ maintainers:
     github: chakAs3
     twitter: ChakirQatab
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional
   devtools: ^0.7.2

--- a/modules/strapi.yml
+++ b/modules/strapi.yml
@@ -16,7 +16,7 @@ maintainers:
     github: Atinux
     twitter: Atinux
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true
   devtools: ^0.0.0

--- a/modules/stripe-next.yml
+++ b/modules/stripe-next.yml
@@ -18,5 +18,5 @@ maintainers:
   - name: Florent Giraud
     github: flozero
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/studio.yml
+++ b/modules/studio.yml
@@ -16,6 +16,6 @@ maintainers:
     github: Atinux
     twitter: Atinux
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     content: true

--- a/modules/stylelint.yml
+++ b/modules/stylelint.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Ricardo Gobbo de Souza
     github: ricardogobbosouza
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/supabase.yml
+++ b/modules/supabase.yml
@@ -19,5 +19,5 @@ maintainers:
     github: scottrobertson
     twitter: scottymeuk
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/surrealdb.yml
+++ b/modules/surrealdb.yml
@@ -13,5 +13,5 @@ maintainers:
     github: sandros94
     avatar: https://avatars.githubusercontent.com/u/13056429
 compatibility:
-  nuxt: ^3.10.0
+  nuxt: '>=3.10.0'
   requires: {}

--- a/modules/svg-sprite.yml
+++ b/modules/svg-sprite.yml
@@ -13,5 +13,5 @@ maintainers:
     github: farnabaz
     twitter: a_birang
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/swiftsearch.yml
+++ b/modules/swiftsearch.yml
@@ -14,5 +14,5 @@ maintainers:
     twitter: MatteoRigoni
     avatar: https://avatars.githubusercontent.com/rigo-m?v=4
 compatibility:
-  nuxt: ^3.10.0
+  nuxt: '>=3.10.0'
   requires: {}

--- a/modules/swiper.yml
+++ b/modules/swiper.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Christian Preston
     github: cpreston321
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/tailvue.yml
+++ b/modules/tailvue.yml
@@ -13,5 +13,5 @@ maintainers:
     github: acidjazz
     twitter: AppFume
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/tailwindcss.yml
+++ b/modules/tailwindcss.yml
@@ -17,7 +17,7 @@ maintainers:
   - name: Inesh Bose
     github: ineshbose
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}
   devtools: ^0.0.0
 aliases:

--- a/modules/test-utils.yml
+++ b/modules/test-utils.yml
@@ -16,5 +16,5 @@ maintainers:
     github: antfu
     twitter: antfu7
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/time.yml
+++ b/modules/time.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: danielroe
     github: danielroe
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/tiptap.yml
+++ b/modules/tiptap.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: modbender
     github: modbender
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/tradingview.yml
+++ b/modules/tradingview.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Volkan Akkuş
     github: volkanakkus
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/translation-manager.yml
+++ b/modules/translation-manager.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Sam K
     github: samk-dev
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/tresjs.yml
+++ b/modules/tresjs.yml
@@ -19,5 +19,5 @@ maintainers:
     github: Tinoooo
     twitter: ichbintino
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/turnstile.yml
+++ b/modules/turnstile.yml
@@ -13,6 +13,6 @@ maintainers:
     github: danielroe
     twitter: danielcroe
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true

--- a/modules/twemoji.yml
+++ b/modules/twemoji.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Yizack Rangel
     github: yizack
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/twicpics.yml
+++ b/modules/twicpics.yml
@@ -21,5 +21,5 @@ maintainers:
     github: mbgspcii
     twitter: m_beignon
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/typed-router.yml
+++ b/modules/typed-router.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: victorgarciaesgi
     github: victorgarciaesgi
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/typo3.yml
+++ b/modules/typo3.yml
@@ -13,6 +13,6 @@ maintainers:
     github: macopedia
     twitter: macopediapl
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}
   devtools: ^0.0.0

--- a/modules/ui.yml
+++ b/modules/ui.yml
@@ -21,5 +21,5 @@ maintainers:
     github: smarroufin
     twitter: smarroufin
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/umami.yml
+++ b/modules/umami.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: ML
     github: ijkml
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/unlazy.yml
+++ b/modules/unlazy.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Johann Schopplich
     github: johannschopplich
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/unocss.yml
+++ b/modules/unocss.yml
@@ -14,7 +14,7 @@ maintainers:
     twitter: antfu7
     avatar: https://avatars.githubusercontent.com/antfu?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional
   devtools: ^0.0.0

--- a/modules/ununuracss.yml
+++ b/modules/ununuracss.yml
@@ -13,5 +13,5 @@ maintainers:
     github: novout
     avatar: https://avatars.githubusercontent.com/novout?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires: {}

--- a/modules/use-bootstrap.yml
+++ b/modules/use-bootstrap.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: KoujiSano
     github: KoujiSano
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vant.yml
+++ b/modules/vant.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: tolking
     github: tolking
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     bridge: optional

--- a/modules/varlet.yml
+++ b/modules/varlet.yml
@@ -12,6 +12,6 @@ maintainers:
   - name: zhangmo8
     github: zhangmo8
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     bridge: optional

--- a/modules/vcalendar.yml
+++ b/modules/vcalendar.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Sam K
     github: samk-dev
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vee-validate.yml
+++ b/modules/vee-validate.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Abdelrahman Awad
     github: logaretm
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vercel-analytics.yml
+++ b/modules/vercel-analytics.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Alexander B.
     github: xanderbarkhatov
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vexip-ui.yml
+++ b/modules/vexip-ui.yml
@@ -15,5 +15,5 @@ maintainers:
     github: qmhc
     twitter: qmhc95
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vite-pwa-nuxt.yml
+++ b/modules/vite-pwa-nuxt.yml
@@ -16,5 +16,5 @@ maintainers:
     github: antfu
     twitter: antfu7
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vue-email.yml
+++ b/modules/vue-email.yml
@@ -18,6 +18,6 @@ maintainers:
     twitter: imflowko
     avatar: https://avatars.githubusercontent.com/u/35883748?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}
   devtools: ^0.0.0

--- a/modules/vue-final-modal.yml
+++ b/modules/vue-final-modal.yml
@@ -13,5 +13,5 @@ maintainers:
     github: hunterliu1003
     twitter: hunterliu1003
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vue-macros.yml
+++ b/modules/vue-macros.yml
@@ -13,7 +13,7 @@ maintainers:
     github: sxzz
     twitter: sanxiaozhizi
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires:
     bridge: optional
   devtools: ^0.0.0

--- a/modules/vue-query.yml
+++ b/modules/vue-query.yml
@@ -13,5 +13,5 @@ maintainers:
     github: Hebilicious
     twitter: its_hebilicious
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vue-transitions.yml
+++ b/modules/vue-transitions.yml
@@ -13,6 +13,6 @@ maintainers:
     github: MorevM
     avatar: https://avatars.githubusercontent.com/u/49679666?v=4
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/vue3-carousel-nuxt.yml
+++ b/modules/vue3-carousel-nuxt.yml
@@ -15,5 +15,5 @@ maintainers:
     github: gaetansenn
     avatar: https://avatars.githubusercontent.com/u/2774075?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vuefire.yml
+++ b/modules/vuefire.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: posva
     github: posva
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vueform-builder.yml
+++ b/modules/vueform-builder.yml
@@ -13,5 +13,5 @@ maintainers:
     github: adamberecz
     twitter: bereczadam
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vueform.yml
+++ b/modules/vueform.yml
@@ -13,5 +13,5 @@ maintainers:
     github: adamberecz
     twitter: bereczadam
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vuestic.yml
+++ b/modules/vuestic.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: epicmaxco
     github: epicmaxco
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vuetify-nuxt-module.yml
+++ b/modules/vuetify-nuxt-module.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Joaquín Sánchez
     github: userquin
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/vueuse.yml
+++ b/modules/vueuse.yml
@@ -13,7 +13,7 @@ maintainers:
     github: antfu
     twitter: antfu7
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional
   devtools: ^0.0.0

--- a/modules/vunix.yml
+++ b/modules/vunix.yml
@@ -17,5 +17,5 @@ maintainers:
     github: gaetansenn
     avatar: https://avatars.githubusercontent.com/u/2774075?v=4
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/web-vitals.yml
+++ b/modules/web-vitals.yml
@@ -18,6 +18,6 @@ maintainers:
     github: Atinux
     twitter: Atinux
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/well-known.yml
+++ b/modules/well-known.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Zadig&Voltaire Team
     github: https://github.com/zadigetvoltaire
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/wideangle.yml
+++ b/modules/wideangle.yml
@@ -14,5 +14,5 @@ maintainers:
   - name: Jarek Rozanski
     github: jrozanski
 compatibility:
-  nuxt: ^3.0.0
+  nuxt: '>=3.0.0'
   requires: {}

--- a/modules/windicss.yml
+++ b/modules/windicss.yml
@@ -16,6 +16,6 @@ maintainers:
     github: antfu
     twitter: antfu7
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: optional

--- a/modules/xstate.yml
+++ b/modules/xstate.yml
@@ -13,6 +13,6 @@ maintainers:
     github: Lexpeartha
     twitter: lexpeartha
 compatibility:
-  nuxt: ^2.0.0 || ^3.0.0
+  nuxt: ^2.0.0 || >=3.0.0
   requires:
     bridge: true


### PR DESCRIPTION
Part of https://github.com/nuxt/nuxt/issues/27613

updated nuxt.com to ensure we don't just look for `^3` in https://github.com/nuxt/nuxt.com/commit/a1bbcc410dda496b2b9434e98713b6a3f1d38ebb but this will need to be fixed properly

We will need to confirm these changes don't break our API.