### PR TITLE
GitHub Contributors Visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,7 @@ pnpm build
 
 [volta-src]: https://user-images.githubusercontent.com/904724/209143798-32345f6c-3cf8-4e06-9659-f4ace4a6acde.svg
 [volta-href]: https://volta.net/nuxt/modules?utm_source=readme_nuxt_modules
+
+## Contributors
+
+<img src="https://markupgo.com/github/nuxt/modules/contributors?count=0&circleSpacing=10&center=true" width="100%" />


### PR DESCRIPTION
## Hello from MarkupGo!

We’re thrilled to introduce a new feature that lets you create a beautiful image showcasing your GitHub contributors. It’s a great way to recognize the amazing people who help make **nuxt module** awesome!

### Here's how it looks:

<img src="https://markupgo.com/github/nuxt/modules/contributors?count=0&circleSpacing=10&center=true" />

### On the Repo page:

![image](https://github.com/user-attachments/assets/a74c5dd7-f78d-467b-99c9-aa4be095cf5b)


### How to configure it:

1. Visit the [GitHub Contributors page on MarkupGo](https://markupgo.com/github?username=nuxt&repo=modules&count=0&circleSpacing=10).
2. Customize the settings to your liking.
3. Click “See Preview” to generate your image.
4. Copy the URL and add it to your README.md file.

![image](https://github.com/user-attachments/assets/400435cf-0974-4fbf-8f34-3598b8058046)


* The image will automatically update as new contributors join your project after caching expires (every 24 hours).