### PR TITLE
chore: fix repository URL for element-plus module

### DIFF
--- a/modules/element-plus.yml
+++ b/modules/element-plus.yml
@@ -3,7 +3,7 @@ description: A Vue 3 based component library for designers and developers
 repo: element-plus/element-plus-nuxt
 npm: '@element-plus/nuxt'
 icon: element-plus.svg
-github: https://github.com/element-plus/element-plus
+github: https://github.com/element-plus/element-plus-nuxt
 website: https://element-plus.org
 learn_more: https://github.com/element-plus/element-plus-nuxt
 category: UI


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1051 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Link to the Github repository actually redirects to Element Plus repo: https://github.com/element-plus/element-plus instead of Nuxt Element Plus repo: https://github.com/element-plus/nuxt-element-plus
