### PR TITLE
fix "icon-tw" icon

### DIFF
--- a/modules/icon-tw.yml
+++ b/modules/icon-tw.yml
@@ -2,7 +2,7 @@ name: icon-tw
 description: Extended Icon module with Tailwind CSS Icons for Nuxt
 repo: jcamp-code/nuxt-icon-tw
 npm: nuxt-icon-tw
-icon: nuxt-icon.png
+icon: tailwindcss.png
 github: https://github.com/jcamp-code/nuxt-icon-tw
 website: https://github.com/jcamp-code/nuxt-icon-tw
 learn_more: ''


### PR DESCRIPTION
Fixes an issue that broke CI tasks

Closes #1082

The "icon-tw" module referenced an icon no longer present, I chanced to one that seems to make the most sense in this context