### PR TITLE
feat: add `nuxt-content-from-api` module

### DIFF
--- a/icons/content-api.svg
+++ b/icons/content-api.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 32 32"><path fill="#00dc82" d="M8 9H4a2 2 0 0 0-2 2v12h2v-5h4v5h2V11a2 2 0 0 0-2-2m-4 7v-5h4v5zm18-5h3v10h-3v2h8v-2h-3V11h3V9h-8zm-8 12h-2V9h6a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-4zm0-7h4v-5h-4z"/></svg>

--- a/modules/content-api.yml
+++ b/modules/content-api.yml
@@ -1,0 +1,16 @@
+name: content-api
+description: Nuxt module for Nuxt Content files
+repo: marlocorridor/nuxt-content-from-api
+npm: nuxt-content-from-api
+icon: content-api.png
+github: https://github.com/marlocorridor/nuxt-content-from-api
+website: https://github.com/marlocorridor/nuxt-content-from-api
+learn_more: ''
+category: CMS
+type: 3rd-party
+maintainers:
+  - name: Marlo Corridor
+    github: marlocorridor
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1114 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Nuxt module for [Nuxt Content](https://content.nuxt.com/). This module takes your API config to create files (.md, .yml, .csv, and .json) to be used by Nuxt Content, thereby accessing full features of Nuxt Content module.

This provides an alternative way of getting your content. For future, we will build this as a Nuxt Content [source](https://content.nuxt.com/get-started/configuration#sources) driver.
