### PR TITLE
feat: add `nuxt-prisma-devtools`

### DIFF
--- a/modules/nuxt-prisma-devtools
+++ b/modules/nuxt-prisma-devtools
@@ -6,7 +6,7 @@ icon: ''
 github: https://github.com/gsxdsm/nuxt-prisma-devtools
 website: https://www.npmjs.com/package/nuxt-prisma-devtools
 learn_more: ''
-category: Database
+category: Devtools
 type: community
 maintainers:
   - name: gsxdsm

--- a/modules/nuxt-prisma-devtools
+++ b/modules/nuxt-prisma-devtools
@@ -1,0 +1,16 @@
+name: nuxt-prisma-devtools
+description: `nuxt-prisma-devtools` integrates Prisma Studio into Nuxt DevTools, without having to use nuxt-prisma. This is useful if you've manually integrated Prisma into Nuxt (or are using a wrapper like Zenstack).
+repo: gsxdsm/nuxt-prisma-devtools
+npm: nuxt-prisma-devtools
+icon: ''
+github: https://github.com/gsxdsm/nuxt-prisma-devtools
+website: https://www.npmjs.com/package/nuxt-prisma-devtools
+learn_more: ''
+category: Database
+type: community
+maintainers:
+  - name: gsxdsm
+    github: gsxdsm
+compatibility:
+  nuxt: >=3.0.0
+  requires: {}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1134 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This module is an integration of [nuxt-prisma-devtools](https://github.com/gsxdsm/nuxt-prisma-devtools). nuxt-prisma-devtools integrates Prisma Studio into Nuxt DevTools, without having to use nuxt-prisma. This is useful if you'd rather not use the full nuxt-prisma integration and rather integrate manually, but want a DevTools integration.
