### PR TITLE
feat: add `@stonecrop/nuxt`

### DIFF
--- a/icons/stonecrop.svg
+++ b/icons/stonecrop.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866668"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (33fec40, 2019-01-16)"
+   sodipodi:docname="aticonrust.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.4568498"
+     inkscape:cx="10.107792"
+     inkscape:cy="27.272488"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:snap-page="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="987"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-263.13332)">
+    <path
+       inkscape:connector-curvature="0"
+       d="M 15.109107,265.76964 3.028,294.36399 h 5.6473807 l 1.1795168,-2.8952 H 23.973357 l 1.179517,2.8952 H 30.836 L 18.754889,265.76964 Z m 4.074697,13.76102 h -4.467868 l 2.251807,-5.50439 z m 2.895177,7.18432 H 11.785015 l 1.000804,-2.43051 h 8.328103 z"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Morden;-inkscape-font-specification:'Morden, Normal';text-align:start;letter-spacing:17.5px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#843c03;fill-opacity:1;stroke:none;stroke-width:0.89357334px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3435" />
+  </g>
+</svg>

--- a/modules/stonecrop.yml
+++ b/modules/stonecrop.yml
@@ -1,0 +1,16 @@
+name: stonecrop
+description: Stonecrop for Nuxt
+repo: agritheory/stonecrop#development/nuxt
+npm: '@stonecrop/nuxt'
+icon: stonecrop.svg
+github: https://github.com/agritheory/stonecrop/tree/development/nuxt
+website: https://agritheory.com/
+learn_more: ''
+category: Libraries
+type: 3rd-party
+maintainers:
+  - name: Tyler Matteson
+    github: agritheory
+compatibility:
+  nuxt: ^3.0.0
+  requires: {}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1150.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This module implements the [`stonecrop`](https://github.com/agritheory/stonecrop) design inside of a Nuxt application. It generates layouts to display arbitrary models and allows extending application routes.
