### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "build": "pnpm cli build",
     "cli": "jiti ./lib/cli",
-    "website:build": "pnpm build && nuxi build website",
-    "website:dev": "pnpm build && nuxi dev website",
+    "website:build": "pnpm build && nuxt build website",
+    "website:dev": "pnpm build && nuxt dev website",
     "lint": "eslint",
     "release": "pnpm cli version && npm publish",
     "sync": "pnpm cli sync",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.