### PR TITLE
feat: add @validex/nuxt module

### DIFF
--- a/modules/validex.yml
+++ b/modules/validex.yml
@@ -1,0 +1,14 @@
+name: validex
+description: Type-safe validation rules built on Zod 4 with structured error codes, i18n, and auto-imported composables
+repo: chiptoma/validex
+npm: '@validex/nuxt'
+icon: ''
+github: https://github.com/chiptoma/validex
+website: https://github.com/chiptoma/validex/tree/main/packages/nuxt
+category: Extensions
+type: community
+maintainers:
+  - name: Ciprian Toma
+    github: chiptoma
+compatibility:
+  nuxt: '>=3.0.0'

--- a/modules/validex.yml
+++ b/modules/validex.yml
@@ -5,6 +5,7 @@ npm: '@validex/nuxt'
 icon: ''
 github: https://github.com/chiptoma/validex
 website: https://github.com/chiptoma/validex/tree/main/packages/nuxt
+learn_more: ''
 category: Extensions
 type: community
 maintainers:
@@ -12,3 +13,4 @@ maintainers:
     github: chiptoma
 compatibility:
   nuxt: '>=3.0.0'
+  requires: {}


### PR DESCRIPTION
### 🔗 Linked issue

N/A — new module submission.

### 📚 Description

Adding @validex/nuxt to the modules directory. It provides 25 typed validation rules built on Zod 4, with auto-imported composables (useValidation + all rule factories), config via nuxt.config.ts, structured error codes, and i18n support.

- npm: @validex/nuxt
- GitHub: https://github.com/chiptoma/validex