### PR TITLE
feat: add `nuxt-c15t`

### DIFF
--- a/icons/c15t.svg
+++ b/icons/c15t.svg
@@ -1,0 +1,123 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" shape-rendering="crispEdges" width="256" height="256">
+  <!-- 8-colour palette inspired by a classic cookie -->
+  <!-- Transparent background. All units are 1×1 pixel squares on a 32×32 grid. -->
+
+  <!-- Cookie body (light brown #C8883D) — roughly circular silhouette -->
+  <g fill="#C8883D">
+    <rect x="11" y="4" width="10" height="1"/>
+    <rect x="8" y="5" width="16" height="1"/>
+    <rect x="7" y="6" width="18" height="1"/>
+    <rect x="6" y="7" width="20" height="1"/>
+    <rect x="5" y="8" width="22" height="1"/>
+    <rect x="5" y="9" width="22" height="1"/>
+    <rect x="4" y="10" width="24" height="1"/>
+    <rect x="4" y="11" width="24" height="1"/>
+    <rect x="4" y="12" width="24" height="1"/>
+    <rect x="4" y="13" width="24" height="1"/>
+    <rect x="4" y="14" width="24" height="1"/>
+    <rect x="4" y="15" width="24" height="1"/>
+    <rect x="4" y="16" width="24" height="1"/>
+    <rect x="4" y="17" width="24" height="1"/>
+    <rect x="4" y="18" width="24" height="1"/>
+    <rect x="4" y="19" width="24" height="1"/>
+    <rect x="4" y="20" width="24" height="1"/>
+    <rect x="4" y="21" width="24" height="1"/>
+    <rect x="5" y="22" width="22" height="1"/>
+    <rect x="5" y="23" width="22" height="1"/>
+    <rect x="6" y="24" width="20" height="1"/>
+    <rect x="7" y="25" width="18" height="1"/>
+    <rect x="8" y="26" width="16" height="1"/>
+    <rect x="11" y="27" width="10" height="1"/>
+  </g>
+
+  <!-- Darker lower-half shading (#9A6A2A) to give a baked look -->
+  <g fill="#9A6A2A">
+    <rect x="5" y="22" width="22" height="1"/>
+    <rect x="5" y="23" width="22" height="1"/>
+    <rect x="6" y="24" width="20" height="1"/>
+    <rect x="7" y="25" width="18" height="1"/>
+    <rect x="8" y="26" width="16" height="1"/>
+    <rect x="11" y="27" width="10" height="1"/>
+  </g>
+
+  <!-- Outline (#5C3A12) -->
+  <g fill="#5C3A12">
+    <!-- top -->
+    <rect x="11" y="3" width="10" height="1"/>
+    <rect x="9" y="4" width="2" height="1"/>
+    <rect x="21" y="4" width="2" height="1"/>
+    <rect x="7" y="5" width="1" height="1"/>
+    <rect x="24" y="5" width="1" height="1"/>
+    <rect x="6" y="6" width="1" height="1"/>
+    <rect x="25" y="6" width="1" height="1"/>
+    <rect x="5" y="7" width="1" height="1"/>
+    <rect x="26" y="7" width="1" height="1"/>
+    <rect x="4" y="8" width="1" height="1"/>
+    <rect x="27" y="8" width="1" height="1"/>
+    <rect x="4" y="9" width="1" height="1"/>
+    <rect x="27" y="9" width="1" height="1"/>
+    <rect x="3" y="10" width="1" height="1"/>
+    <rect x="28" y="10" width="1" height="1"/>
+    <!-- sides -->
+    <rect x="3" y="11" width="1" height="10"/>
+    <rect x="28" y="11" width="1" height="10"/>
+    <!-- bottom -->
+    <rect x="3" y="21" width="1" height="1"/>
+    <rect x="28" y="21" width="1" height="1"/>
+    <rect x="4" y="22" width="1" height="1"/>
+    <rect x="27" y="22" width="1" height="1"/>
+    <rect x="4" y="23" width="1" height="1"/>
+    <rect x="27" y="23" width="1" height="1"/>
+    <rect x="5" y="24" width="1" height="1"/>
+    <rect x="26" y="24" width="1" height="1"/>
+    <rect x="6" y="25" width="1" height="1"/>
+    <rect x="25" y="25" width="1" height="1"/>
+    <rect x="7" y="26" width="1" height="1"/>
+    <rect x="24" y="26" width="1" height="1"/>
+    <rect x="8" y="27" width="3" height="1"/>
+    <rect x="21" y="27" width="3" height="1"/>
+    <rect x="11" y="28" width="10" height="1"/>
+  </g>
+
+  <!-- Chocolate chips (dark brown #3A1E08 for shadow, #5C3A12 for body) -->
+  <!-- Top-left chip -->
+  <rect x="9"  y="9"  width="3" height="1" fill="#3A1E08"/>
+  <rect x="8"  y="10" width="4" height="2" fill="#3A1E08"/>
+  <rect x="9"  y="12" width="3" height="1" fill="#3A1E08"/>
+  <rect x="9"  y="9"  width="2" height="1" fill="#5C3A12"/>
+  <rect x="8"  y="10" width="3" height="1" fill="#5C3A12"/>
+
+  <!-- Top-right chip -->
+  <rect x="19" y="8"  width="3" height="1" fill="#3A1E08"/>
+  <rect x="18" y="9"  width="4" height="2" fill="#3A1E08"/>
+  <rect x="19" y="11" width="3" height="1" fill="#3A1E08"/>
+  <rect x="19" y="8"  width="2" height="1" fill="#5C3A12"/>
+  <rect x="18" y="9"  width="3" height="1" fill="#5C3A12"/>
+
+  <!-- Middle chip -->
+  <rect x="13" y="15" width="3" height="1" fill="#3A1E08"/>
+  <rect x="12" y="16" width="4" height="2" fill="#3A1E08"/>
+  <rect x="13" y="18" width="3" height="1" fill="#3A1E08"/>
+  <rect x="13" y="15" width="2" height="1" fill="#5C3A12"/>
+  <rect x="12" y="16" width="3" height="1" fill="#5C3A12"/>
+
+  <!-- Bottom-right chip -->
+  <rect x="20" y="17" width="3" height="1" fill="#3A1E08"/>
+  <rect x="19" y="18" width="4" height="2" fill="#3A1E08"/>
+  <rect x="20" y="20" width="3" height="1" fill="#3A1E08"/>
+  <rect x="20" y="17" width="2" height="1" fill="#5C3A12"/>
+  <rect x="19" y="18" width="3" height="1" fill="#5C3A12"/>
+
+  <!-- Bottom-left chip -->
+  <rect x="8"  y="19" width="3" height="1" fill="#3A1E08"/>
+  <rect x="7"  y="20" width="4" height="2" fill="#3A1E08"/>
+  <rect x="8"  y="22" width="3" height="1" fill="#3A1E08"/>
+  <rect x="8"  y="19" width="2" height="1" fill="#5C3A12"/>
+  <rect x="7"  y="20" width="3" height="1" fill="#5C3A12"/>
+
+  <!-- Small crumb highlights (#F2C892) -->
+  <rect x="15" y="7"  width="1" height="1" fill="#F2C892"/>
+  <rect x="22" y="13" width="1" height="1" fill="#F2C892"/>
+  <rect x="6"  y="15" width="1" height="1" fill="#F2C892"/>
+  <rect x="17" y="24" width="1" height="1" fill="#F2C892"/>
+</svg>

--- a/modules/c15t.yml
+++ b/modules/c15t.yml
@@ -1,0 +1,18 @@
+name: c15t
+description: >-
+  Nuxt module for c15t consent management — reactive composables, headless
+  components, Nuxt Scripts integration, and vendor-aware cookie policy tables
+repo: rolleyio/nuxt-c15t
+npm: nuxt-c15t
+icon: c15t.svg
+github: https://github.com/rolleyio/nuxt-c15t
+website: https://nuxt-c15t.rolley.io
+learn_more: ''
+category: Extensions
+type: 3rd-party
+maintainers:
+  - name: Matthew Rollinson
+    github: matt-rolley
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}


### PR DESCRIPTION
Adds [nuxt-c15t](https://github.com/rolleyio/nuxt-c15t) to the catalogue.

Nuxt module for GDPR / CMP consent management: headless components, reactive composables, Nuxt Scripts integration for consent-gated script loading, and a vendor cookie registry covering 16+ common third parties (Google Analytics, Meta Pixel, Hotjar, YouTube, Stripe, Directus, Medusa, etc.).

**Links**
- npm: https://www.npmjs.com/package/nuxt-c15t
- docs: https://nuxt-c15t.rolley.io
- playground: https://playground.nuxt-c15t.rolley.io
- GitHub: https://github.com/rolleyio/nuxt-c15t

Category \`Extensions\` to match \`cookie-control\` (the existing cookie-consent entry). Type \`3rd-party\`.