### PR TITLE
fead: add `@b10cks/nuxt` module (#1463)

### DIFF
--- a/icons/b10cks.svg
+++ b/icons/b10cks.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><defs><style>.c{fill:#fff}</style></defs><path d="M0 0h512v512H0z"/><path d="M224 224h64v64h-64zM96 96h64v256H96z" class="c"/><path d="M352 352H160v64h256V160h-64zM224 96h128v64H224z" class="c"/></svg>

--- a/modules/b10cks.yml
+++ b/modules/b10cks.yml
@@ -1,0 +1,17 @@
+name: b10cks CMS
+description: b10cks CMS Nuxt module
+repo: b10cks/sdk#main/packages/nuxt
+npm: '@b10cks/nuxt'
+icon: b10cks.png
+github: https://github.com/b10cks/sdk
+website: https://github.com/b10cks/sdk/tree/main/packages/nuxt
+learn_more: ''
+category: CMS
+type: 3rd-party
+maintainers:
+  - name: b10cks
+    github: b10cks
+compatibility:
+  nuxt: ^4.0.0
+  requires: {}
+  devtools: ^0.0.0


### PR DESCRIPTION
Adds [@b10cks/nuxt](https://github.com/b10cks/sdk) to the catalogue.

**b10cks** is an open-source headless CMS with a visual infinite-canvas editor, modular block architecture, built-in localization, CDN delivery, and git-like version history. The `@b10cks/nuxt` module provides first-class Nuxt integration via the b10cks SDK.

**Links**
- npm: https://www.npmjs.com/package/@b10cks/nuxt
- GitHub: https://github.com/b10cks/sdk/tree/main/packages/nuxt

Category `CMS`. Type `3rd-party`.