### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/modules/maz-ui.yml
+++ b/modules/maz-ui.yml
@@ -12,9 +12,9 @@ learn_more: https://maz-ui.com/guide/nuxt
 category: UI
 type: 3rd-party
 maintainers:
-  - name: Mazel (Loïc Mazuel)
+  - name: Mazel
     github: LouisMazel
-    twitter: Mazeel
+    twitter: maz__ui
 compatibility:
   nuxt: '>=3.0.0'
   requires: {}

--- a/modules/turnstile.yml
+++ b/modules/turnstile.yml
@@ -5,7 +5,7 @@ npm: '@nuxtjs/turnstile'
 icon: cloudflare.svg
 github: https://github.com/nuxt-modules/turnstile
 website: https://github.com/nuxt-modules/turnstile
-learn_more: https://www.cloudflare.com/application-services/products/turnstile/
+learn_more: https://www.cloudflare.com/products/turnstile/
 category: Security
 type: community
 maintainers:

--- a/package.json
+++ b/package.json
@@ -42,5 +42,5 @@
     "std-env": "^4.1.0",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`