### PR TITLE
feat: add nuxt-openapi-hyperfetch module

### DIFF
--- a/modules/nuxt-openapi-hyperfetch.yml
+++ b/modules/nuxt-openapi-hyperfetch.yml
@@ -1,0 +1,17 @@
+name: nuxt-openapi-hyperfetch
+description: Generate useFetch and useAsyncData composables on top of the OpenAPI client with Nuxt-friendly wrappers and auto-import support.
+repo: dmartindiaz/nuxt-openapi-hyperfetch
+npm: nuxt-openapi-hyperfetch
+icon: ''
+github: https://github.com/dmartindiaz/nuxt-openapi-hyperfetch
+website: https://nuxt-openapi-hyperfetch.netlify.app/
+learn_more: ''
+category: Request
+type: 3rd-party
+maintainers:
+  - name: Jan Hug
+    github: dmartindiaz
+    avatar: https://avatars.githubusercontent.com/dmartindiaz?v=4
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}

--- a/modules/nuxt-openapi-hyperfetch.yml
+++ b/modules/nuxt-openapi-hyperfetch.yml
@@ -9,7 +9,7 @@ learn_more: ''
 category: Request
 type: 3rd-party
 maintainers:
-  - name: Jan Hug
+  - name: Daniel Martín Díaz
     github: dmartindiaz
     avatar: https://avatars.githubusercontent.com/dmartindiaz?v=4
 compatibility:

--- a/modules/nuxt-openapi-hyperfetch.yml
+++ b/modules/nuxt-openapi-hyperfetch.yml
@@ -1,5 +1,7 @@
 name: nuxt-openapi-hyperfetch
-description: Generate useFetch and useAsyncData composables on top of the OpenAPI client with Nuxt-friendly wrappers and auto-import support.
+description: >-
+  Generate useFetch and useAsyncData composables on top of the OpenAPI client
+  with Nuxt-friendly wrappers and auto-import support.
 repo: dmartindiaz/nuxt-openapi-hyperfetch
 npm: nuxt-openapi-hyperfetch
 icon: ''
@@ -9,7 +11,7 @@ learn_more: ''
 category: Request
 type: 3rd-party
 maintainers:
-  - name: Daniel Martín Díaz
+  - name: DANIEL MARTIN DIAZ
     github: dmartindiaz
     avatar: https://avatars.githubusercontent.com/dmartindiaz?v=4
 compatibility:


### PR DESCRIPTION
The module uses an OpenAPI document as input and generates a layered output. It generate a typed OpenAPI client, Nuxt composables, optional server routes, and headless connectors.

Base output under `openapi/`:

- typed SDK functions
- generated OpenAPI types
- generated client files and barrel exports

Optional higher-level layers:

- useFetch composables
- useAsyncData composables
- nuxtServer Nitro routes
- headless CRUD connectors