### PR TITLE
feat: add nuxt-api-sdk

### DIFF
--- a/icons/api-sdk.svg
+++ b/icons/api-sdk.svg
@@ -1,0 +1,12 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>api-sdk</title>
+  <g stroke="#00DC82" stroke-width="14" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M100 56 C 80 56, 80 70, 80 100 C 80 120, 70 128, 60 128 C 70 128, 80 136, 80 156 C 80 186, 80 200, 100 200"/>
+    <path d="M156 56 C 176 56, 176 70, 176 100 C 176 120, 186 128, 196 128 C 186 128, 176 136, 176 156 C 176 186, 176 200, 156 200"/>
+  </g>
+  <g fill="#00DC82">
+    <circle cx="108" cy="128" r="9"/>
+    <circle cx="128" cy="128" r="9"/>
+    <circle cx="148" cy="128" r="9"/>
+  </g>
+</svg>

--- a/modules/api-sdk.yml
+++ b/modules/api-sdk.yml
@@ -2,7 +2,7 @@ name: api-sdk
 description: Turn nuxt server routes into an SDK
 repo: jamiecurnow/nuxt-api-sdk
 npm: nuxt-api-sdk
-icon: ''
+icon: api-sdk.svg
 github: https://github.com/jamiecurnow/nuxt-api-sdk
 website: https://github.com/jamiecurnow/nuxt-api-sdk
 learn_more: ''

--- a/modules/api-sdk.yml
+++ b/modules/api-sdk.yml
@@ -12,5 +12,5 @@ maintainers:
   - name: Jamie Curnow
     github: JamieCurnow
 compatibility:
-  nuxt: '>=3.0.0'
+  nuxt: '>=4.0.0'
   requires: {}

--- a/modules/api-sdk.yml
+++ b/modules/api-sdk.yml
@@ -1,0 +1,16 @@
+name: api-sdk
+description: Turn nuxt server routes into an SDK
+repo: jamiecurnow/nuxt-api-sdk
+npm: nuxt-api-sdk
+icon: ''
+github: https://github.com/jamiecurnow/nuxt-api-sdk
+website: https://github.com/jamiecurnow/nuxt-api-sdk
+learn_more: ''
+category: Request
+type: 3rd-party
+maintainers:
+  - name: Jamie Curnow
+    github: JamieCurnow
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}


### PR DESCRIPTION
🔗 Linked issue: closes #1312

📚 Description: adds [`nuxt-api-sdk`](https://github.com/jamiecurnow/nuxt-api-sdk) ([npm](https://www.npmjs.com/package/nuxt-api-sdk)).

A Nuxt module that turns your `server/api` routes into a fully-typed, chainable SDK. It scans your Nitro handlers and generates a `useApi()` composable with end-to-end type-safety and autocompletion, so you can call `useApi().user.uid(uid).get()` instead of `$fetch(`/api/user/${uid}`)`. Also ships a `defineBodyType` utility for typing request bodies.

Category: `Request`