### PR TITLE
feat: add unirate module (@unirate/nuxt)

### DIFF
--- a/modules/unirate.yml
+++ b/modules/unirate.yml
@@ -1,0 +1,20 @@
+name: unirate
+description: >-
+  Connect your Nuxt app to the UniRate currency-exchange API. Server proxy that
+  keeps your API key server-side, useUniRate() and useCurrency() composables,
+  useUniRateClient() server util, and <Currency> / <Rate> components.
+repo: UniRate-API/nuxt-unirate
+npm: '@unirate/nuxt'
+icon: ''
+github: https://github.com/UniRate-API/nuxt-unirate
+website: https://github.com/UniRate-API/nuxt-unirate#readme
+learn_more: https://unirateapi.com
+category: Request
+type: 3rd-party
+maintainers:
+  - name: rob-browncc
+    github: rob-browncc
+    avatar: https://avatars.githubusercontent.com/u/199503049?v=4
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}


### PR DESCRIPTION
Adds `@unirate/nuxt` to the modules listing.

[`@unirate/nuxt`](https://github.com/UniRate-API/nuxt-unirate) is a Nuxt 3/4 module for the [UniRate](https://unirateapi.com) currency-exchange API:

- **Server proxy** that keeps your API key server-side — the browser only ever talks to your own app, even during SSR hydration; the proxy forwards an allow-listed set of paths.
- `useUniRate()` (universal) + `useCurrency()` (Accept-Language detection) composables, plus a `useUniRateClient()` server util.
- `<Currency>` / `<Rate>` `Intl`-formatting components.
- **Zero runtime dependencies** (`@nuxt/kit` is a peer); published to npm with provenance attestation; CI green on Nuxt 3 + 4 / Node 20 + 22.

- npm: https://www.npmjs.com/package/@unirate/nuxt
- repo: https://github.com/UniRate-API/nuxt-unirate

_Disclosure: I maintain this module and am affiliated with UniRate._
