### PR TITLE
feat: add nuxt-email

### DIFF
--- a/icons/nuxt-email.svg
+++ b/icons/nuxt-email.svg
@@ -1,0 +1,6 @@
+<svg width="600" height="600" viewBox="0 0 600 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="600" height="600" rx="132" fill="#18181B"/>
+  <g transform="translate(160 160) scale(11.7)" fill="none" stroke="#00DC82" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M3 8l7.89 5.26a2 2 0 0 0 2.22 0L21 8M5 19h14a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2z"/>
+  </g>
+</svg>

--- a/modules/nuxt-email.yml
+++ b/modules/nuxt-email.yml
@@ -1,0 +1,14 @@
+name: nuxt-email
+description: Transactional email for Nuxt 4 with multi-provider support and Vue templates
+repo: razmatinyan/nuxt-email
+npm: '@razmatinyan/nuxt-email'
+github: https://github.com/razmatinyan/nuxt-email
+website: https://github.com/razmatinyan/nuxt-email#readme
+category: Extensions
+type: 3rd-party
+maintainers:
+  - name: Razmik Matinyan
+    github: razmatinyan
+compatibility:
+  nuxt: '>=4.0.0'
+  requires: {}

--- a/modules/nuxt-email.yml
+++ b/modules/nuxt-email.yml
@@ -4,6 +4,7 @@ repo: razmatinyan/nuxt-email
 npm: '@razmatinyan/nuxt-email'
 github: https://github.com/razmatinyan/nuxt-email
 website: https://github.com/razmatinyan/nuxt-email#readme
+learn_more: https://stackblitz.com/github/razmatinyan/nuxt-email-demo
 category: Extensions
 type: 3rd-party
 maintainers:


### PR DESCRIPTION
Adds `@razmatinyan/nuxt-email` to the registry.

Transactional email for Nuxt 4 - a provider-agnostic server API with Vue-powered email templates.

- **Providers:** Resend, SendGrid, Postmark, SMTP, and a `console` provider for local dev
- **Templates:** author emails as `.vue` files, rendered on the server and CSS-inlined
- Per-provider credentials, attachments, CC/BCC, tags, scheduling, retries, and batch sending
- Nuxt DevTools **Email** tab (template preview, test send, send log)

**Live demo:** https://stackblitz.com/github/razmatinyan/nuxt-email-demo
The `console` provider works out of the box (it logs to the terminal). To test Resend, SendGrid, or Postmark in the demo, add your own API key via a `.env` file (see the demo's `.env.example`) and restart.

Links:
- npm: https://www.npmjs.com/package/@razmatinyan/nuxt-email
- Repo: https://github.com/razmatinyan/nuxt-email
