### PR TITLE
feat: add nvcalendar

### DIFF
--- a/icons/nvcalendar.svg
+++ b/icons/nvcalendar.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" role="img" aria-label="nvcalendar">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#297cef"/>
+      <stop offset="1" stop-color="#0462d3"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="48" height="48" rx="11" fill="url(#bg)"/>
+
+  <g fill="none" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round">
+    <rect x="10" y="12" width="28" height="26" rx="5"/>
+    <path d="M10 20h28"/>
+    <path d="M17 8v6M31 8v6"/>
+  </g>
+
+  <g fill="#ffffff">
+    <circle cx="17" cy="27" r="2"/>
+    <circle cx="24" cy="27" r="2"/>
+    <circle cx="31" cy="27" r="2"/>
+    <circle cx="17" cy="33" r="2"/>
+    <circle cx="24" cy="33" r="2"/>
+  </g>
+</svg>

--- a/modules/bcms.yml
+++ b/modules/bcms.yml
@@ -4,8 +4,8 @@ repo: bcms/nuxt-module
 npm: '@thebcms/nuxt'
 icon: bcms.png
 github: https://github.com/bcms/nuxt-module
-website: https://thebcms.com
-learn_more: https://thebcms.com/docs/integrations/nuxt-js
+website: https://www.thebcms.com/
+learn_more: https://www.thebcms.com/docs/integrations/nuxt-js/
 category: CMS
 type: 3rd-party
 maintainers:

--- a/modules/nvcalendar.yml
+++ b/modules/nvcalendar.yml
@@ -1,0 +1,22 @@
+name: nvcalendar
+description: >-
+  Calendar, date picker and attribute-driven date visualisation. Zero runtime
+  dependencies, Intl-powered locales, light and dark themes, fully typed.
+repo: msdoc11/nvcalendar
+npm: nvcalendar
+icon: nvcalendar.svg
+github: https://github.com/msdoc11/nvcalendar
+website: https://github.com/msdoc11/nvcalendar
+learn_more: https://github.com/msdoc11/nvcalendar#readme
+category: UI
+type: 3rd-party
+maintainers:
+  - name: Nik
+    github: msdoc11
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}
+aliases:
+  - calendar
+  - datepicker
+  - date-picker


### PR DESCRIPTION
### Linked issue

No issue — this PR adds a new module to the registry.

### Description

Adds `nvcalendar` to the module registry.

`nvcalendar` is a calendar and date picker for Nuxt 3 and 4. It supports multiple month views, single, multiple, and range selection, an optional time picker, and date attributes for highlights, dots, bars, and popovers.

Localization is handled through the native `Intl` API, so no locale files are bundled. The module has no runtime dependencies besides `@nuxt/kit` and can also be used in plain Vue 3 through a separate entry point.

The package is already published as `nvcalendar@0.1.0`.

This PR adds:

- `modules/nvcalendar.yml`
- `icons/nvcalendar.svg`

I ran `pnpm cli sync nvcalendar` and `pnpm lint` locally, and both completed without issues.

The `website` field currently points to the GitHub repository. I'll update it once the documentation site has its own domain.
