### PR TITLE
feat: add nuxt-endpoints module

### DIFF
--- a/icons/nuxt-endpoints.svg
+++ b/icons/nuxt-endpoints.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Nuxt Endpoints">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00dc82" />
+      <stop offset="1" stop-color="#36e4da" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="112" fill="#020420" />
+  <polygon points="180,132 400,132 372,196 152,196" fill="url(#bg)" />
+  <polygon points="166,224 320,224 292,288 138,288" fill="url(#bg)" />
+  <polygon points="152,316 372,316 344,380 124,380" fill="url(#bg)" />
+</svg>

--- a/modules/nuxt-charts.yml
+++ b/modules/nuxt-charts.yml
@@ -1,7 +1,7 @@
 name: nuxt-charts
 description: Nuxt module for vue-chrts
 repo: dennisadriaans/vue-chrts#main/packages/nuxt-charts
-npm: nuxt-charts-legacy
+npm: nuxt-charts
 icon: nuxt-charts.svg
 github: https://github.com/dennisadriaans/vue-chrts
 website: https://nuxtcharts.com/

--- a/modules/nuxt-endpoints.yml
+++ b/modules/nuxt-endpoints.yml
@@ -11,7 +11,7 @@ learn_more: https://nuxt-endpoints.github.io/nuxt-endpoints/docs/getting-started
 category: Request
 type: 3rd-party
 maintainers:
-  - name: Yoshinori Ishii
+  - name: y.ishii
     github: yoshinoriishii
 compatibility:
   nuxt: ^4.5.0

--- a/modules/nuxt-endpoints.yml
+++ b/modules/nuxt-endpoints.yml
@@ -1,0 +1,18 @@
+name: nuxt-endpoints
+description: >-
+  Typed APIs, generated clients, and OpenAPI for Nuxt server routes — from one
+  endpoint definition
+repo: nuxt-endpoints/nuxt-endpoints
+npm: nuxt-endpoints
+icon: nuxt-endpoints.svg
+github: https://github.com/nuxt-endpoints/nuxt-endpoints
+website: https://nuxt-endpoints.github.io/nuxt-endpoints/
+learn_more: https://nuxt-endpoints.github.io/nuxt-endpoints/docs/getting-started
+category: Request
+type: 3rd-party
+maintainers:
+  - name: Yoshinori Ishii
+    github: yoshinoriishii
+compatibility:
+  nuxt: ^4.5.0
+  requires: {}

--- a/modules/pinia.yml
+++ b/modules/pinia.yml
@@ -14,6 +14,6 @@ maintainers:
     twitter: posva
     bluesky: esm.dev
 compatibility:
-  nuxt: ^3.15.0 || ^4.0.0
+  nuxt: ^3.15.0 || ^4.0.0 || ^5.0.0
   requires:
     bridge: optional


### PR DESCRIPTION
### 🔗 Linked issue

- Resolves https://github.com/nuxt/modules/issues/1584

### 📚 Description

This PR adds nuxt-endpoints to the Nuxt modules registry.

nuxt-endpoints brings RPC-like end-to-end type safety to native Nuxt server routes without replacing Nuxt’s file-based routing. Users define a contract alongside each handler with Zod, Valibot, or Effect Schema, and the module derives:

- Runtime-validated params, query, headers, and body
- A status-aware typed client
- An OpenAPI 3.1 document from the same contract
- Typed TanStack Vue Query options, including queries, mutations, infinite queries, and stable query keys

This preserves HTTP methods, status codes, and OpenAPI interoperability while avoiding duplicated request and response types or manually maintained Query keys. Idempotency support is also available for mutation endpoints.

Nuxt Endpoints is designed to adopt Nuxt 5 typed-fetch and stable H3/Nitro metadata primitives as they become available, while keeping executable contracts, status-aware results, runtime validation, and optional client adapters at the module layer.

The metadata was synced against the published nuxt-endpoints@0.2.0 package, and the registry build completed successfully.