### PR TITLE
feat: add nuxt-maplibre-gl module

### DIFF
--- a/modules/nuxt-maplibre-gl.yml
+++ b/modules/nuxt-maplibre-gl.yml
@@ -11,7 +11,7 @@ learn_more: https://vue-maplibre-gl.pages.dev/guide/getting-started
 category: Libraries
 type: 3rd-party
 maintainers:
-  - name: Danh Nguyen
+  - name: Harry Nguyen
     github: danh121097
 compatibility:
   nuxt: '>=3.0.0'

--- a/modules/nuxt-maplibre-gl.yml
+++ b/modules/nuxt-maplibre-gl.yml
@@ -1,0 +1,18 @@
+name: nuxt-maplibre-gl
+description: >-
+  Nuxt module for vue3-maplibre-gl — auto-import components, composables, CSS,
+  and SSR configuration
+repo: danh121097/vue-maplibre-gl#master/nuxt
+npm: nuxt-maplibre-gl
+icon: maplibre.png
+github: https://github.com/danh121097/vue-maplibre-gl
+website: https://vue-maplibre-gl.pages.dev/
+learn_more: https://vue-maplibre-gl.pages.dev/guide/getting-started
+category: Libraries
+type: 3rd-party
+maintainers:
+  - name: Danh Nguyen
+    github: danh121097
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}


### PR DESCRIPTION
Adds [`nuxt-maplibre-gl`](https://www.npmjs.com/package/nuxt-maplibre-gl), a Nuxt module for [`vue3-maplibre-gl`](https://www.npmjs.com/package/vue3-maplibre-gl) — a MapLibre GL JS component library for Vue 3.

The module auto-imports the 10 components and 38 composables, injects both stylesheets, and configures SSR (client-only plugin, `maplibre-gl` excluded from the SSR bundle since it needs WebGL).

- npm: `nuxt-maplibre-gl@2.0.0`
- Docs: https://vue-maplibre-gl.pages.dev/
- Source: https://github.com/danh121097/vue-maplibre-gl/tree/master/nuxt
- Nuxt compatibility: `>=3.0.0`

Generated with `pnpm sync nuxt-maplibre-gl danh121097/vue-maplibre-gl#master/nuxt`, then filled in `category` (`Libraries`, matching `nuxt-mapbox`, `nuxt-maplibre` and `@nuxtjs/leaflet`) and `icon` (reusing the existing `maplibre.png`).