### PR TITLE
chore(modules): update nuxt-notify metadata

### DIFF
--- a/modules/nuxt-notify.yml
+++ b/modules/nuxt-notify.yml
@@ -1,8 +1,8 @@
 name: nuxt-notify
 description: >-
   Toast notifications for Nuxt 3/4 by Levi Labs. Tailwind CSS + Nuxt Icon with
-  actions, avatars, progress bars, themes, and per-toast UI overrides. Lightweight
-  (~1.6 kB gzipped), type-safe, and SSR-friendly.
+  actions, avatars, progress bars, themes, and per-toast UI overrides.
+  Lightweight (~1.6 kB gzipped), type-safe, and SSR-friendly.
 repo: nizaamomer/nuxt-notify
 npm: nuxt-notify
 icon: nuxt-notify.png

--- a/modules/nuxt-notify.yml
+++ b/modules/nuxt-notify.yml
@@ -1,7 +1,8 @@
 name: nuxt-notify
 description: >-
-  Advanced toast notifications for Nuxt 3/4 with Tailwind CSS + Nuxt Icon
-  (actions, avatars, progress, themes, UI overrides).
+  Toast notifications for Nuxt 3/4 by Levi Labs. Tailwind CSS + Nuxt Icon with
+  actions, avatars, progress bars, themes, and per-toast UI overrides. Lightweight
+  (~1.6 kB gzipped), type-safe, and SSR-friendly.
 repo: nizaamomer/nuxt-notify
 npm: nuxt-notify
 icon: nuxt-notify.png
@@ -13,6 +14,28 @@ type: 3rd-party
 maintainers:
   - name: Nizam Omer
     github: nizaamomer
+  - name: Levi Labs
+    github: levilabs-dev
 compatibility:
   nuxt: ^3.0.0 || ^4.0.0
   requires: {}
+aliases:
+  - toast
+  - notifications
+  - notify
+  - toast-notifications
+  - toastify
+  - snackbar
+  - snackbars
+  - alert
+  - alerts
+  - notifier
+  - nuxt-toast
+  - vue-toast
+  - messages
+  - notification
+  - toast-message
+  - toast-messages
+  - ui-toast
+  - flash-message
+  - flash-messages


### PR DESCRIPTION
### 🔗 Linked issue

N/A — updates existing listing.

### 📚 Description

Updates the nuxt-notify module listing:

- Refreshed description (Levi Labs, bundle size, SSR-friendly)
- Added Levi Labs as maintainer
- Added search aliases (toast, snackbar, notify, etc.)