### PR TITLE
feat: add nuxt-maptiler-gl module

### DIFF
--- a/icons/nuxt-maptiler-gl.svg
+++ b/icons/nuxt-maptiler-gl.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Vue MapTiler SDK">
+  <rect width="32" height="32" rx="7" fill="#10b981"/>
+  <g stroke="#fff" stroke-opacity=".35" stroke-width="1">
+    <path d="M11 5V27M21 5V27M5 11H27M5 21H27"/>
+  </g>
+  <path d="M16 9c-3 0-5.4 2.4-5.4 5.4 0 4 5.4 9.1 5.4 9.1s5.4-5.1 5.4-9.1C21.4 11.4 19 9 16 9Z" fill="#fff"/>
+  <circle cx="16" cy="14.4" r="2" fill="#10b981"/>
+</svg>

--- a/modules/nuxt-maptiler-gl.yml
+++ b/modules/nuxt-maptiler-gl.yml
@@ -1,0 +1,16 @@
+name: nuxt-maptiler-gl
+description: MapTiler SDK integration with Nuxt
+repo: danh121097/vue-maptiler-gl#master/nuxt
+npm: nuxt-maptiler-gl
+icon: nuxt-maptiler-gl.svg
+github: https://github.com/danh121097/vue-maptiler-gl
+website: https://vue-maptiler-gl.pages.dev/
+learn_more: https://vue-maptiler-gl.pages.dev/guide/ssr-nuxt
+category: Libraries
+type: 3rd-party
+maintainers:
+  - name: Danh Nguyen
+    github: danh121097
+compatibility:
+  nuxt: '>=3.0.0'
+  requires: {}

--- a/modules/nuxt-maptiler-gl.yml
+++ b/modules/nuxt-maptiler-gl.yml
@@ -9,7 +9,7 @@ learn_more: https://vue-maptiler-gl.pages.dev/guide/ssr-nuxt
 category: Libraries
 type: 3rd-party
 maintainers:
-  - name: Danh Nguyen
+  - name: Harry Nguyen
     github: danh121097
 compatibility:
   nuxt: '>=3.0.0'


### PR DESCRIPTION
Adds [`nuxt-maptiler-gl`](https://www.npmjs.com/package/nuxt-maptiler-gl), a Nuxt module wrapping [`vue3-maptiler-gl`](https://www.npmjs.com/package/vue3-maptiler-gl) — Vue 3 components and composables for the [MapTiler SDK](https://docs.maptiler.com/sdk-js/).

It auto-imports the 10 components and 38 composables, injects both stylesheets, and registers the client plugin the SDK needs under SSR.

- npm: `nuxt-maptiler-gl` (2.0.2, MIT)
- Docs: https://vue-maptiler-gl.pages.dev/ — Nuxt guide at https://vue-maptiler-gl.pages.dev/guide/ssr-nuxt
- Repo: https://github.com/danh121097/vue-maptiler-gl (module source under `nuxt/`)
- Compatibility: `nuxt >=3.0.0`

`pnpm sync nuxt-maptiler-gl danh121097/vue-maptiler-gl#master/nuxt`, `pnpm lint` and `pnpm build` all pass locally. The icon is this project's own logo, not MapTiler branding.